### PR TITLE
feat: add remote signing support + make some functions public

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,10 @@ name: Publish
 on:
   push:
     tags:
-      - "*"
+      # Trigger this workflow when tag follows the versioning format: v<major>.<minor>.<patch> OR v<major>.<minor>.<patch>-rc.<release_candidate>
+      # Example valid tags: v0.4.0, v0.4.0-rc.1
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -28,7 +28,7 @@ env:
   rust_msrv: "1.85"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}-${{ github.event_name }}
   cancel-in-progress: true
 
 permissions:
@@ -42,11 +42,62 @@ jobs:
     steps:
       - run: echo 'The Publish workflow passed or was manually triggered'
 
-  sdist:
+  validate-release-tag:
     runs-on: ubuntu-latest
     needs: [check-cargo-publish]
+    outputs:
+      cargo-version: ${{ steps.validate.outputs.cargo-version }}
+      is-rc: ${{ steps.validate.outputs.is-rc }}
+    steps:
+      - name: Validate release tag format
+        id: validate
+        # Note, `workflow_run.head_branch` does not contain `refs/tags/` prefix, just the tag name, i.e. `v0.4.0` or `v0.4.0-rc.1`
+        # Valid formats: v<major>.<minor>.<patch> OR v<major>.<minor>.<patch>-rc.<release_candidate>
+        run: |
+          RELEASE_TAG="${{ github.event.workflow_run.head_branch }}"
+          echo "Validating release tag: $RELEASE_TAG"
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
+            echo "❌ Invalid release tag format: $RELEASE_TAG"
+            echo "Expected format: v<major>.<minor>.<patch> OR v<major>.<minor>.<patch>-rc.<release_candidate>"
+            echo "Examples: v0.4.0, v1.2.3-rc.1"
+            exit 1
+          fi
+          echo "✅ Release tag format is valid: $RELEASE_TAG"
+          
+          # Strip 'v' prefix for cargo version
+          CARGO_VERSION="${RELEASE_TAG#v}"
+          echo "Cargo version (without v prefix): $CARGO_VERSION"
+          
+          # Check if this is a release candidate
+          if [[ "$RELEASE_TAG" =~ -rc\.[0-9]+$ ]]; then
+            IS_RC="true"
+            echo "This is a release candidate"
+          else
+            IS_RC="false"
+            echo "This is a stable release"
+          fi
+          
+          # Set outputs for other jobs to use
+          echo "cargo-version=$CARGO_VERSION" >> $GITHUB_OUTPUT
+          echo "is-rc=$IS_RC" >> $GITHUB_OUTPUT
+
+  sdist:
+    runs-on: ubuntu-latest
+    needs: [validate-release-tag]
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install cargo-edit
+        if: ${{ needs.validate-release-tag.outputs.is-rc == 'true' }}
+        run: cargo install cargo-edit
+      
+      - name: Set cargo version for RC
+        if: ${{ needs.validate-release-tag.outputs.is-rc == 'true' }}
+        working-directory: "bindings/python"
+        run: |
+          echo "Setting cargo version to: ${{ needs.validate-release-tag.outputs.cargo-version }}"
+          cargo set-version ${{ needs.validate-release-tag.outputs.cargo-version }}
+
       - uses: PyO3/maturin-action@v1
         with:
           working-directory: "bindings/python"
@@ -60,7 +111,7 @@ jobs:
 
   wheels:
     runs-on: "${{ matrix.os }}"
-    needs: [check-cargo-publish]
+    needs: [validate-release-tag]
     strategy:
       matrix:
         include:
@@ -75,6 +126,18 @@ jobs:
           - { os: ubuntu-latest, target: "armv7l" }
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install cargo-edit
+        if: ${{ needs.validate-release-tag.outputs.is-rc == 'true' }}
+        run: cargo install cargo-edit
+      
+      - name: Set cargo version for RC
+        if: ${{ needs.validate-release-tag.outputs.is-rc == 'true' }}
+        working-directory: "bindings/python"
+        run: |
+          echo "Setting cargo version to: ${{ needs.validate-release-tag.outputs.cargo-version }}"
+          cargo set-version ${{ needs.validate-release-tag.outputs.cargo-version }}
+
       - uses: actions/setup-python@v5
         with:
           python-version: 3.9
@@ -99,9 +162,6 @@ jobs:
     name: Publish Python 🐍 distribution 📦 to Pypi
     needs: [sdist, wheels]
     runs-on: ubuntu-latest
-    # Only publish to PyPi if the tag is not a pre-release OR if manually triggered
-    # Note, `workflow_run.head_branch` does not contain `refs/tags/` prefix, just the tag name, i.e. `v0.4.0` or `v0.4.0-rc.1`
-    if: ${{ !contains(github.event.workflow_run.head_branch, '-') || github.event_name == 'workflow_dispatch' }}
 
     environment:
       name: pypi

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -100,7 +100,8 @@ jobs:
     needs: [sdist, wheels]
     runs-on: ubuntu-latest
     # Only publish to PyPi if the tag is not a pre-release OR if manually triggered
-    if: ${{ (startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-')) || github.event_name == 'workflow_dispatch' }}
+    # Note, `workflow_run.head_branch` does not contain `refs/tags/` prefix, just the tag name, i.e. `v0.4.0` or `v0.4.0-rc.1`
+    if: ${{ !contains(github.event.workflow_run.head_branch, '-') || github.event_name == 'workflow_dispatch' }}
 
     environment:
       name: pypi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2645,6 +2645,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+
+[[package]]
 name = "educe"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6055,6 +6061,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6216,15 +6234,16 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.9.0",
+ "schemars",
  "serde",
  "serde_derive",
  "serde_json",
@@ -6234,9 +6253,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,9 +633,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.6.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fcc63c9860579e4cb396239570e979376e70aab79e496621748a09913f8b36"
+checksum = "02a18fd934af6ae7ca52410d4548b98eb895aab0f1ea417d168d85db1434a141"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -766,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.66.0"
+version = "1.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "858007b14d0f1ade2e0124473c2126b24d334dc9486ad12eb7c0ed14757be464"
+checksum = "13118ad30741222f67b1a18e5071385863914da05124652b38e172d6d3d9ce31"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -782,16 +782,15 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "once_cell",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.67.0"
+version = "1.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b83abf3ae8bd10a014933cc2383964a12ca5a3ebbe1948ad26b1b808e7d0d1f2"
+checksum = "f879a8572b4683a8f84f781695bebf2f25cf11a81a2693c31fc0e0215c2c1726"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -805,16 +804,15 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "once_cell",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.67.0"
+version = "1.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e8e9ac4a837859c8f1d747054172e1e55933f02ed34728b0b34dea0591ec84"
+checksum = "f1e9c3c24e36183e2f698235ed38dcfbbdff1d09b9232dc866c4be3011e0b47e"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -829,7 +827,6 @@ dependencies = [
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "once_cell",
  "regex-lite",
  "tracing",
 ]
@@ -1537,7 +1534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4197,7 +4194,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -7678,7 +7675,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "as-any"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f477b951e452a0b6b4a10b53ccd569042d1d01729b519e02074a9c0958a063"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3488,6 +3494,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "arrow-string",
+ "as-any",
  "async-std",
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3699,7 +3699,7 @@ dependencies = [
  "iceberg-catalog-rest",
  "iceberg-datafusion",
  "iceberg_test_utils",
- "ordered-float 2.10.1",
+ "ordered-float 4.6.0",
  "parquet",
  "tokio",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4200,7 +4200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4767,8 +4767,7 @@ checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 [[package]]
 name = "opendal"
 version = "0.53.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f947c4efbca344c1a125753366033c8107f552b2e3f8251815ed1908f116ca3e"
+source = "git+https://github.com/advanced-development/opendal.git?branch=remote-signer#918fc44d0225e6a4a4ab52944a1dd50f2a6dd11e"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ arrow-ord = { version = "55" }
 arrow-schema = { version = "55" }
 arrow-select = { version = "55" }
 arrow-string = { version = "55" }
+as-any = "0.3.2"
 async-std = "1.12"
 async-trait = "0.1.88"
 aws-config = "1.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ motore-macros = "0.4.3"
 murmur3 = "0.5.2"
 num-bigint = "0.4.6"
 once_cell = "1.20"
-opendal = "0.53.3"
+opendal = { git = "https://github.com/advanced-development/opendal.git", branch = "remote-signer" }
 ordered-float = "4"
 parquet = "55"
 pilota = "0.11.2"

--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -770,7 +770,8 @@ impl Catalog for RestCatalog {
                 return Err(Error::new(
                     ErrorKind::Unexpected,
                     "CommitFailedException, one or more requirements failed. The client may retry.",
-                ));
+                )
+                .with_retryable(true));
             }
             StatusCode::INTERNAL_SERVER_ERROR => {
                 return Err(Error::new(

--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -54,6 +54,7 @@ arrow-ord = { workspace = true }
 arrow-schema = { workspace = true }
 arrow-select = { workspace = true }
 arrow-string = { workspace = true }
+as-any = { workspace = true }
 async-std = { workspace = true, optional = true, features = ["attributes"] }
 async-trait = { workspace = true }
 base64 = { workspace = true }

--- a/crates/iceberg/src/error.rs
+++ b/crates/iceberg/src/error.rs
@@ -134,6 +134,8 @@ pub struct Error {
 
     source: Option<anyhow::Error>,
     backtrace: Backtrace,
+
+    retryable: bool,
 }
 
 impl Display for Error {
@@ -225,7 +227,15 @@ impl Error {
             // `Backtrace::capture()` will check if backtrace has been enabled
             // internally. It's zero cost if backtrace is disabled.
             backtrace: Backtrace::capture(),
+
+            retryable: false,
         }
+    }
+
+    /// Set retryable of the error.
+    pub fn with_retryable(mut self, retryable: bool) -> Self {
+        self.retryable = retryable;
+        self
     }
 
     /// Add more context in error.

--- a/crates/iceberg/src/error.rs
+++ b/crates/iceberg/src/error.rs
@@ -39,7 +39,7 @@ pub enum ErrorKind {
     /// Iceberg data is invalid.
     ///
     /// This error is returned when we try to read a table from iceberg but
-    /// failed to parse it's metadata or data file correctly.
+    /// failed to parse its metadata or data file correctly.
     ///
     /// The table could be invalid or corrupted.
     DataInvalid,

--- a/crates/iceberg/src/expr/visitors/manifest_evaluator.rs
+++ b/crates/iceberg/src/expr/visitors/manifest_evaluator.rs
@@ -23,6 +23,43 @@ use crate::expr::{BoundPredicate, BoundReference};
 use crate::spec::{Datum, FieldSummary, ManifestFile, PrimitiveLiteral, Type};
 use crate::{Error, ErrorKind, Result};
 
+/// Builder for [`ManifestEvaluator`] with optional NOT rewriting capability.
+#[derive(Debug)]
+pub(crate) struct ManifestEvaluatorBuilder {
+    partition_filter: BoundPredicate,
+    rewrite_not: bool,
+}
+
+impl ManifestEvaluatorBuilder {
+    /// Creates a new `ManifestEvaluatorBuilder` with the given partition filter.
+    pub(crate) fn new(partition_filter: BoundPredicate) -> Self {
+        Self {
+            partition_filter,
+            rewrite_not: false,
+        }
+    }
+
+    /// Enables NOT rewriting optimization for the partition filter.
+    /// When enabled, the builder will apply NOT elimination to simplify the predicate
+    /// before creating the evaluator.
+    #[allow(unused)]
+    pub(crate) fn with_rewrite_not(mut self, rewrite_not: bool) -> Self {
+        self.rewrite_not = rewrite_not;
+        self
+    }
+
+    /// Builds the `ManifestEvaluator` with the configured options.
+    pub(crate) fn build(self) -> ManifestEvaluator {
+        let partition_filter = if self.rewrite_not {
+            self.partition_filter.rewrite_not()
+        } else {
+            self.partition_filter
+        };
+
+        ManifestEvaluator { partition_filter }
+    }
+}
+
 /// Evaluates a [`ManifestFile`] to see if the partition summaries
 /// match a provided [`BoundPredicate`].
 ///
@@ -34,8 +71,9 @@ pub(crate) struct ManifestEvaluator {
 }
 
 impl ManifestEvaluator {
-    pub(crate) fn new(partition_filter: BoundPredicate) -> Self {
-        Self { partition_filter }
+    /// Creates a new `ManifestEvaluatorBuilder` for building a `ManifestEvaluator`.
+    pub(crate) fn builder(partition_filter: BoundPredicate) -> ManifestEvaluatorBuilder {
+        ManifestEvaluatorBuilder::new(partition_filter)
     }
 
     /// Evaluate this `ManifestEvaluator`'s filter predicate against the
@@ -86,8 +124,11 @@ impl BoundPredicateVisitor for ManifestFilterVisitor<'_> {
         Ok(lhs || rhs)
     }
 
-    fn not(&mut self, inner: bool) -> crate::Result<bool> {
-        Ok(!inner)
+    fn not(&mut self, _: bool) -> crate::Result<bool> {
+        Err(Error::new(
+            ErrorKind::Unexpected,
+            "not operator is not supported in partition filter",
+        ))
     }
 
     fn is_null(
@@ -674,7 +715,11 @@ mod test {
 
         let filter = Predicate::AlwaysTrue.bind(schema.clone(), case_sensitive)?;
 
-        assert!(ManifestEvaluator::new(filter).eval(&manifest_file)?);
+        assert!(
+            ManifestEvaluator::builder(filter)
+                .build()
+                .eval(&manifest_file)?
+        );
 
         Ok(())
     }
@@ -688,7 +733,11 @@ mod test {
 
         let filter = Predicate::AlwaysFalse.bind(schema.clone(), case_sensitive)?;
 
-        assert!(!ManifestEvaluator::new(filter).eval(&manifest_file)?);
+        assert!(
+            !ManifestEvaluator::builder(filter)
+                .build()
+                .eval(&manifest_file)?
+        );
 
         Ok(())
     }
@@ -707,7 +756,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            !ManifestEvaluator::new(all_nulls_missing_nan_filter).eval(&manifest_file)?,
+            !ManifestEvaluator::builder(all_nulls_missing_nan_filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should skip: all nulls column with non-floating type contains all null"
         );
 
@@ -718,7 +769,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            ManifestEvaluator::new(all_nulls_missing_nan_float_filter).eval(&manifest_file)?,
+            ManifestEvaluator::builder(all_nulls_missing_nan_float_filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should read: no NaN information may indicate presence of NaN value"
         );
 
@@ -729,7 +782,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            ManifestEvaluator::new(some_nulls_filter).eval(&manifest_file)?,
+            ManifestEvaluator::builder(some_nulls_filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should read: column with some nulls contains a non-null value"
         );
 
@@ -741,7 +796,9 @@ mod test {
         .bind(schema.clone(), case_sensitive)?;
 
         assert!(
-            ManifestEvaluator::new(no_nulls_filter).eval(&manifest_file)?,
+            ManifestEvaluator::builder(no_nulls_filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should read: non-null column contains a non-null value"
         );
 
@@ -762,7 +819,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            ManifestEvaluator::new(all_nulls_missing_nan_filter).eval(&manifest_file)?,
+            ManifestEvaluator::builder(all_nulls_missing_nan_filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should read: at least one null value in all null column"
         );
 
@@ -773,7 +832,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            ManifestEvaluator::new(some_nulls_filter).eval(&manifest_file)?,
+            ManifestEvaluator::builder(some_nulls_filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should read: column with some nulls contains a null value"
         );
 
@@ -785,7 +846,9 @@ mod test {
         .bind(schema.clone(), case_sensitive)?;
 
         assert!(
-            !ManifestEvaluator::new(no_nulls_filter).eval(&manifest_file)?,
+            !ManifestEvaluator::builder(no_nulls_filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should skip: non-null column contains no null values"
         );
 
@@ -796,7 +859,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            ManifestEvaluator::new(both_nan_and_null_filter).eval(&manifest_file)?,
+            ManifestEvaluator::builder(both_nan_and_null_filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should read: both_nan_and_null column contains no null values"
         );
 
@@ -817,7 +882,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            ManifestEvaluator::new(float_filter).eval(&manifest_file)?,
+            ManifestEvaluator::builder(float_filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should read: no information on if there are nan value in float column"
         );
 
@@ -828,7 +895,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            ManifestEvaluator::new(all_nulls_double_filter).eval(&manifest_file)?,
+            ManifestEvaluator::builder(all_nulls_double_filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should read: no NaN information may indicate presence of NaN value"
         );
 
@@ -839,7 +908,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            ManifestEvaluator::new(all_nulls_missing_nan_float_filter).eval(&manifest_file)?,
+            ManifestEvaluator::builder(all_nulls_missing_nan_float_filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should read: no NaN information may indicate presence of NaN value"
         );
 
@@ -850,7 +921,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            !ManifestEvaluator::new(all_nulls_no_nans_filter).eval(&manifest_file)?,
+            !ManifestEvaluator::builder(all_nulls_no_nans_filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should skip: no nan column doesn't contain nan value"
         );
 
@@ -861,7 +934,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            ManifestEvaluator::new(all_nans_filter).eval(&manifest_file)?,
+            ManifestEvaluator::builder(all_nans_filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should read: all_nans column contains nan value"
         );
 
@@ -872,7 +947,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            ManifestEvaluator::new(both_nan_and_null_filter).eval(&manifest_file)?,
+            ManifestEvaluator::builder(both_nan_and_null_filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should read: both_nan_and_null column contains nan value"
         );
 
@@ -883,7 +960,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            !ManifestEvaluator::new(no_nan_or_null_filter).eval(&manifest_file)?,
+            !ManifestEvaluator::builder(no_nan_or_null_filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should skip: no_nan_or_null column doesn't contain nan value"
         );
 
@@ -904,7 +983,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            ManifestEvaluator::new(float_filter).eval(&manifest_file)?,
+            ManifestEvaluator::builder(float_filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should read: no information on if there are nan value in float column"
         );
 
@@ -915,7 +996,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            ManifestEvaluator::new(all_nulls_double_filter).eval(&manifest_file)?,
+            ManifestEvaluator::builder(all_nulls_double_filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should read: all null column contains non nan value"
         );
 
@@ -926,7 +1009,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            ManifestEvaluator::new(all_nulls_no_nans_filter).eval(&manifest_file)?,
+            ManifestEvaluator::builder(all_nulls_no_nans_filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should read: no_nans column contains non nan value"
         );
 
@@ -937,7 +1022,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            !ManifestEvaluator::new(all_nans_filter).eval(&manifest_file)?,
+            !ManifestEvaluator::builder(all_nans_filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should skip: all nans column doesn't contain non nan value"
         );
 
@@ -948,7 +1035,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            ManifestEvaluator::new(both_nan_and_null_filter).eval(&manifest_file)?,
+            ManifestEvaluator::builder(both_nan_and_null_filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should read: both_nan_and_null nans column contains non nan value"
         );
 
@@ -959,7 +1048,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            ManifestEvaluator::new(no_nan_or_null_filter).eval(&manifest_file)?,
+            ManifestEvaluator::builder(no_nan_or_null_filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should read: no_nan_or_null column contains non nan value"
         );
 
@@ -985,7 +1076,9 @@ mod test {
         )))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            !ManifestEvaluator::new(filter).eval(&manifest_file)?,
+            !ManifestEvaluator::builder(filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should read: no information on if there are nan value in float column"
         );
 
@@ -1011,7 +1104,9 @@ mod test {
         )))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            !ManifestEvaluator::new(filter).eval(&manifest_file)?,
+            !ManifestEvaluator::builder(filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should skip: or(false, false)"
         );
 
@@ -1033,7 +1128,23 @@ mod test {
         .not()
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            ManifestEvaluator::new(filter).eval(&manifest_file)?,
+            ManifestEvaluator::builder(filter)
+                .build()
+                .eval(&manifest_file)
+                .is_err(),
+        );
+        let filter = Predicate::Binary(BinaryExpression::new(
+            PredicateOperator::LessThan,
+            Reference::new("id"),
+            Datum::int(INT_MIN_VALUE - 25),
+        ))
+        .not()
+        .rewrite_not()
+        .bind(schema.clone(), case_sensitive)?;
+        assert!(
+            ManifestEvaluator::builder(filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should read: not(false)"
         );
 
@@ -1045,7 +1156,24 @@ mod test {
         .not()
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            !ManifestEvaluator::new(filter).eval(&manifest_file)?,
+            ManifestEvaluator::builder(filter)
+                .build()
+                .eval(&manifest_file)
+                .is_err()
+        );
+
+        let filter = Predicate::Binary(BinaryExpression::new(
+            PredicateOperator::GreaterThan,
+            Reference::new("id"),
+            Datum::int(INT_MIN_VALUE - 25),
+        ))
+        .not()
+        .rewrite_not()
+        .bind(schema.clone(), case_sensitive)?;
+        assert!(
+            !ManifestEvaluator::builder(filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should skip: not(true)"
         );
 
@@ -1066,7 +1194,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            !ManifestEvaluator::new(filter).eval(&manifest_file)?,
+            !ManifestEvaluator::builder(filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should not read: id range below lower bound (5 < 30)"
         );
 
@@ -1087,7 +1217,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            !ManifestEvaluator::new(filter).eval(&manifest_file)?,
+            !ManifestEvaluator::builder(filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should not read: id range below lower bound (5 < 30)"
         );
 
@@ -1108,7 +1240,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            !ManifestEvaluator::new(filter).eval(&manifest_file)?,
+            !ManifestEvaluator::builder(filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should not read: id range above upper bound (85 < 79)"
         );
 
@@ -1129,7 +1263,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            !ManifestEvaluator::new(filter).eval(&manifest_file)?,
+            !ManifestEvaluator::builder(filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should not read: id range above upper bound (85 < 79)"
         );
 
@@ -1140,7 +1276,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            ManifestEvaluator::new(filter).eval(&manifest_file)?,
+            ManifestEvaluator::builder(filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should read: one possible id"
         );
 
@@ -1161,7 +1299,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            !ManifestEvaluator::new(filter).eval(&manifest_file)?,
+            !ManifestEvaluator::builder(filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should not read: id below lower bound"
         );
 
@@ -1172,7 +1312,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            ManifestEvaluator::new(filter).eval(&manifest_file)?,
+            ManifestEvaluator::builder(filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should read: id equal to lower bound"
         );
 
@@ -1193,7 +1335,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            ManifestEvaluator::new(filter).eval(&manifest_file)?,
+            ManifestEvaluator::builder(filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should read: id below lower bound"
         );
 
@@ -1217,7 +1361,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            !ManifestEvaluator::new(filter).eval(&manifest_file)?,
+            !ManifestEvaluator::builder(filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should not read: id below lower bound (5 < 30, 6 < 30)"
         );
 
@@ -1231,7 +1377,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            ManifestEvaluator::new(filter).eval(&manifest_file)?,
+            ManifestEvaluator::builder(filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should read: id equal to lower bound (30 == 30)"
         );
 
@@ -1255,7 +1403,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            ManifestEvaluator::new(filter).eval(&manifest_file)?,
+            ManifestEvaluator::builder(filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should read: id below lower bound (5 < 30, 6 < 30)"
         );
 
@@ -1276,7 +1426,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            ManifestEvaluator::new(filter).eval(&manifest_file)?,
+            ManifestEvaluator::builder(filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should read: range matches"
         );
 
@@ -1287,7 +1439,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            !ManifestEvaluator::new(filter).eval(&manifest_file)?,
+            !ManifestEvaluator::builder(filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should skip: range doesn't match"
         );
 
@@ -1308,7 +1462,9 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            ManifestEvaluator::new(filter).eval(&manifest_file)?,
+            ManifestEvaluator::builder(filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should read: range matches"
         );
 
@@ -1319,8 +1475,63 @@ mod test {
         ))
         .bind(schema.clone(), case_sensitive)?;
         assert!(
-            !ManifestEvaluator::new(filter).eval(&manifest_file)?,
+            !ManifestEvaluator::builder(filter)
+                .build()
+                .eval(&manifest_file)?,
             "Should not read: all values start with the prefix"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_manifest_evaluator_builder_with_rewrite() -> Result<()> {
+        let case_sensitive = true;
+        let schema = create_schema()?;
+        let partitions = create_partitions();
+        let manifest_file = create_manifest_file(partitions);
+
+        // Create a predicate with NOT that should be rewritten
+        // NOT(id < 25) should become (id >= 25)
+        let filter = Predicate::Binary(BinaryExpression::new(
+            PredicateOperator::LessThan,
+            Reference::new("id"),
+            Datum::int(25), // This is less than our range [30, 79]
+        ))
+        .not()
+        .bind(schema.clone(), case_sensitive)?;
+
+        // Test without rewrite - should fail because NOT is not supported
+        let evaluator = ManifestEvaluator::builder(filter.clone())
+            .with_rewrite_not(false)
+            .build();
+        assert!(
+            evaluator.eval(&manifest_file).is_err(),
+            "Should error: NOT is not supported without rewrite"
+        );
+
+        // Test with rewrite enabled - should succeed
+        let evaluator = ManifestEvaluator::builder(filter)
+            .with_rewrite_not(true)
+            .build();
+        let result = evaluator.eval(&manifest_file)?;
+        assert!(
+            result,
+            "Should read: NOT(id < 25) becomes (id >= 25), which matches our range [30, 79]"
+        );
+
+        // Test default behavior (no rewrite) with a simple predicate
+        let simple_filter = Predicate::Binary(BinaryExpression::new(
+            PredicateOperator::GreaterThan,
+            Reference::new("id"),
+            Datum::int(20),
+        ))
+        .bind(schema, case_sensitive)?;
+
+        let evaluator = ManifestEvaluator::builder(simple_filter).build();
+        assert!(
+            evaluator.eval(&manifest_file)?,
+            "Should read: simple predicate without NOT works by default"
         );
 
         Ok(())

--- a/crates/iceberg/src/expr/visitors/mod.rs
+++ b/crates/iceberg/src/expr/visitors/mod.rs
@@ -21,6 +21,8 @@ pub(crate) mod inclusive_metrics_evaluator;
 pub(crate) mod inclusive_projection;
 pub(crate) mod manifest_evaluator;
 pub(crate) mod page_index_evaluator;
+pub(crate) mod predicate_visitor;
+pub(crate) mod rewrite_not;
 pub(crate) mod row_group_metrics_evaluator;
 pub(crate) mod strict_metrics_evaluator;
 pub(crate) mod strict_projection;

--- a/crates/iceberg/src/expr/visitors/predicate_visitor.rs
+++ b/crates/iceberg/src/expr/visitors/predicate_visitor.rs
@@ -1,0 +1,673 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use fnv::FnvHashSet;
+
+use crate::Result;
+use crate::expr::{Predicate, PredicateOperator, Reference};
+use crate::spec::Datum;
+
+/// A visitor for [`Predicate`]s. Visits in post-order.
+pub trait PredicateVisitor {
+    /// The return type of this visitor
+    type T;
+
+    /// Called after an `AlwaysTrue` predicate is visited
+    fn always_true(&mut self) -> Result<Self::T>;
+
+    /// Called after an `AlwaysFalse` predicate is visited
+    fn always_false(&mut self) -> Result<Self::T>;
+
+    /// Called after an `And` predicate is visited
+    fn and(&mut self, lhs: Self::T, rhs: Self::T) -> Result<Self::T>;
+
+    /// Called after an `Or` predicate is visited
+    fn or(&mut self, lhs: Self::T, rhs: Self::T) -> Result<Self::T>;
+
+    /// Called after a `Not` predicate is visited
+    fn not(&mut self, inner: Self::T) -> Result<Self::T>;
+
+    /// Called after a predicate with an `IsNull` operator is visited
+    fn is_null(&mut self, reference: &Reference, predicate: &Predicate) -> Result<Self::T>;
+
+    /// Called after a predicate with a `NotNull` operator is visited
+    fn not_null(&mut self, reference: &Reference, predicate: &Predicate) -> Result<Self::T>;
+
+    /// Called after a predicate with an `IsNan` operator is visited
+    fn is_nan(&mut self, reference: &Reference, predicate: &Predicate) -> Result<Self::T>;
+
+    /// Called after a predicate with a `NotNan` operator is visited
+    fn not_nan(&mut self, reference: &Reference, predicate: &Predicate) -> Result<Self::T>;
+
+    /// Called after a predicate with a `LessThan` operator is visited
+    fn less_than(
+        &mut self,
+        reference: &Reference,
+        literal: &Datum,
+        predicate: &Predicate,
+    ) -> Result<Self::T>;
+
+    /// Called after a predicate with a `LessThanOrEq` operator is visited
+    fn less_than_or_eq(
+        &mut self,
+        reference: &Reference,
+        literal: &Datum,
+        predicate: &Predicate,
+    ) -> Result<Self::T>;
+
+    /// Called after a predicate with a `GreaterThan` operator is visited
+    fn greater_than(
+        &mut self,
+        reference: &Reference,
+        literal: &Datum,
+        predicate: &Predicate,
+    ) -> Result<Self::T>;
+
+    /// Called after a predicate with a `GreaterThanOrEq` operator is visited
+    fn greater_than_or_eq(
+        &mut self,
+        reference: &Reference,
+        literal: &Datum,
+        predicate: &Predicate,
+    ) -> Result<Self::T>;
+
+    /// Called after a predicate with an `Eq` operator is visited
+    fn eq(
+        &mut self,
+        reference: &Reference,
+        literal: &Datum,
+        predicate: &Predicate,
+    ) -> Result<Self::T>;
+
+    /// Called after a predicate with a `NotEq` operator is visited
+    fn not_eq(
+        &mut self,
+        reference: &Reference,
+        literal: &Datum,
+        predicate: &Predicate,
+    ) -> Result<Self::T>;
+
+    /// Called after a predicate with a `StartsWith` operator is visited
+    fn starts_with(
+        &mut self,
+        reference: &Reference,
+        literal: &Datum,
+        predicate: &Predicate,
+    ) -> Result<Self::T>;
+
+    /// Called after a predicate with a `NotStartsWith` operator is visited
+    fn not_starts_with(
+        &mut self,
+        reference: &Reference,
+        literal: &Datum,
+        predicate: &Predicate,
+    ) -> Result<Self::T>;
+
+    /// Called after a predicate with an `In` operator is visited
+    fn r#in(
+        &mut self,
+        reference: &Reference,
+        literals: &FnvHashSet<Datum>,
+        predicate: &Predicate,
+    ) -> Result<Self::T>;
+
+    /// Called after a predicate with a `NotIn` operator is visited
+    fn not_in(
+        &mut self,
+        reference: &Reference,
+        literals: &FnvHashSet<Datum>,
+        predicate: &Predicate,
+    ) -> Result<Self::T>;
+}
+
+/// Visits a [`Predicate`] with the provided visitor,
+/// in post-order
+pub(crate) fn visit<V: PredicateVisitor>(visitor: &mut V, predicate: &Predicate) -> Result<V::T> {
+    match predicate {
+        Predicate::AlwaysTrue => visitor.always_true(),
+        Predicate::AlwaysFalse => visitor.always_false(),
+        Predicate::And(expr) => {
+            let [left_pred, right_pred] = expr.inputs();
+
+            let left_result = visit(visitor, left_pred)?;
+            let right_result = visit(visitor, right_pred)?;
+
+            visitor.and(left_result, right_result)
+        }
+        Predicate::Or(expr) => {
+            let [left_pred, right_pred] = expr.inputs();
+
+            let left_result = visit(visitor, left_pred)?;
+            let right_result = visit(visitor, right_pred)?;
+
+            visitor.or(left_result, right_result)
+        }
+        Predicate::Not(expr) => {
+            let [inner_pred] = expr.inputs();
+
+            let inner_result = visit(visitor, inner_pred)?;
+
+            visitor.not(inner_result)
+        }
+        Predicate::Unary(expr) => match expr.op() {
+            PredicateOperator::IsNull => visitor.is_null(expr.term(), predicate),
+            PredicateOperator::NotNull => visitor.not_null(expr.term(), predicate),
+            PredicateOperator::IsNan => visitor.is_nan(expr.term(), predicate),
+            PredicateOperator::NotNan => visitor.not_nan(expr.term(), predicate),
+            op => {
+                panic!("Unexpected op for unary predicate: {}", &op)
+            }
+        },
+        Predicate::Binary(expr) => {
+            let reference = expr.term();
+            let literal = expr.literal();
+            match expr.op() {
+                PredicateOperator::LessThan => visitor.less_than(reference, literal, predicate),
+                PredicateOperator::LessThanOrEq => {
+                    visitor.less_than_or_eq(reference, literal, predicate)
+                }
+                PredicateOperator::GreaterThan => {
+                    visitor.greater_than(reference, literal, predicate)
+                }
+                PredicateOperator::GreaterThanOrEq => {
+                    visitor.greater_than_or_eq(reference, literal, predicate)
+                }
+                PredicateOperator::Eq => visitor.eq(reference, literal, predicate),
+                PredicateOperator::NotEq => visitor.not_eq(reference, literal, predicate),
+                PredicateOperator::StartsWith => visitor.starts_with(reference, literal, predicate),
+                PredicateOperator::NotStartsWith => {
+                    visitor.not_starts_with(reference, literal, predicate)
+                }
+                op => {
+                    panic!("Unexpected op for binary predicate: {}", &op)
+                }
+            }
+        }
+        Predicate::Set(expr) => {
+            let reference = expr.term();
+            let literals = expr.literals();
+            match expr.op() {
+                PredicateOperator::In => visitor.r#in(reference, literals, predicate),
+                PredicateOperator::NotIn => visitor.not_in(reference, literals, predicate),
+                op => {
+                    panic!("Unexpected op for set predicate: {}", &op)
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Not;
+
+    use fnv::FnvHashSet;
+
+    use crate::expr::visitors::predicate_visitor::{PredicateVisitor, visit};
+    use crate::expr::{
+        BinaryExpression, Predicate, PredicateOperator, Reference, SetExpression, UnaryExpression,
+    };
+    use crate::spec::Datum;
+
+    struct TestEvaluator {}
+    impl PredicateVisitor for TestEvaluator {
+        type T = bool;
+
+        fn always_true(&mut self) -> crate::Result<Self::T> {
+            Ok(true)
+        }
+
+        fn always_false(&mut self) -> crate::Result<Self::T> {
+            Ok(false)
+        }
+
+        fn and(&mut self, lhs: Self::T, rhs: Self::T) -> crate::Result<Self::T> {
+            Ok(lhs && rhs)
+        }
+
+        fn or(&mut self, lhs: Self::T, rhs: Self::T) -> crate::Result<Self::T> {
+            Ok(lhs || rhs)
+        }
+
+        fn not(&mut self, inner: Self::T) -> crate::Result<Self::T> {
+            Ok(!inner)
+        }
+
+        fn is_null(
+            &mut self,
+            _reference: &Reference,
+            _predicate: &Predicate,
+        ) -> crate::Result<bool> {
+            Ok(true)
+        }
+
+        fn not_null(
+            &mut self,
+            _reference: &Reference,
+            _predicate: &Predicate,
+        ) -> crate::Result<bool> {
+            Ok(false)
+        }
+
+        fn is_nan(
+            &mut self,
+            _reference: &Reference,
+            _predicate: &Predicate,
+        ) -> crate::Result<bool> {
+            Ok(true)
+        }
+
+        fn not_nan(
+            &mut self,
+            _reference: &Reference,
+            _predicate: &Predicate,
+        ) -> crate::Result<bool> {
+            Ok(false)
+        }
+
+        fn less_than(
+            &mut self,
+            _reference: &Reference,
+            _literal: &Datum,
+            _predicate: &Predicate,
+        ) -> crate::Result<bool> {
+            Ok(true)
+        }
+
+        fn less_than_or_eq(
+            &mut self,
+            _reference: &Reference,
+            _literal: &Datum,
+            _predicate: &Predicate,
+        ) -> crate::Result<bool> {
+            Ok(false)
+        }
+
+        fn greater_than(
+            &mut self,
+            _reference: &Reference,
+            _literal: &Datum,
+            _predicate: &Predicate,
+        ) -> crate::Result<bool> {
+            Ok(true)
+        }
+
+        fn greater_than_or_eq(
+            &mut self,
+            _reference: &Reference,
+            _literal: &Datum,
+            _predicate: &Predicate,
+        ) -> crate::Result<bool> {
+            Ok(false)
+        }
+
+        fn eq(
+            &mut self,
+            _reference: &Reference,
+            _literal: &Datum,
+            _predicate: &Predicate,
+        ) -> crate::Result<bool> {
+            Ok(true)
+        }
+
+        fn not_eq(
+            &mut self,
+            _reference: &Reference,
+            _literal: &Datum,
+            _predicate: &Predicate,
+        ) -> crate::Result<bool> {
+            Ok(false)
+        }
+
+        fn starts_with(
+            &mut self,
+            _reference: &Reference,
+            _literal: &Datum,
+            _predicate: &Predicate,
+        ) -> crate::Result<bool> {
+            Ok(true)
+        }
+
+        fn not_starts_with(
+            &mut self,
+            _reference: &Reference,
+            _literal: &Datum,
+            _predicate: &Predicate,
+        ) -> crate::Result<bool> {
+            Ok(false)
+        }
+
+        fn r#in(
+            &mut self,
+            _reference: &Reference,
+            _literals: &FnvHashSet<Datum>,
+            _predicate: &Predicate,
+        ) -> crate::Result<bool> {
+            Ok(true)
+        }
+
+        fn not_in(
+            &mut self,
+            _reference: &Reference,
+            _literals: &FnvHashSet<Datum>,
+            _predicate: &Predicate,
+        ) -> crate::Result<bool> {
+            Ok(false)
+        }
+    }
+
+    #[test]
+    fn test_always_true() {
+        let predicate = Predicate::AlwaysTrue;
+
+        let mut test_evaluator = TestEvaluator {};
+
+        let result = visit(&mut test_evaluator, &predicate);
+
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn test_always_false() {
+        let predicate = Predicate::AlwaysFalse;
+
+        let mut test_evaluator = TestEvaluator {};
+
+        let result = visit(&mut test_evaluator, &predicate);
+
+        assert!(!result.unwrap());
+    }
+
+    #[test]
+    fn test_logical_and() {
+        let predicate = Predicate::AlwaysTrue.and(Predicate::AlwaysFalse);
+
+        let mut test_evaluator = TestEvaluator {};
+
+        let result = visit(&mut test_evaluator, &predicate);
+
+        assert!(!result.unwrap());
+
+        let predicate = Predicate::AlwaysFalse.and(Predicate::AlwaysFalse);
+
+        let mut test_evaluator = TestEvaluator {};
+
+        let result = visit(&mut test_evaluator, &predicate);
+
+        assert!(!result.unwrap());
+
+        let predicate = Predicate::AlwaysTrue.and(Predicate::AlwaysTrue);
+
+        let mut test_evaluator = TestEvaluator {};
+
+        let result = visit(&mut test_evaluator, &predicate);
+
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn test_logical_or() {
+        let predicate = Predicate::AlwaysTrue.or(Predicate::AlwaysFalse);
+
+        let mut test_evaluator = TestEvaluator {};
+
+        let result = visit(&mut test_evaluator, &predicate);
+
+        assert!(result.unwrap());
+
+        let predicate = Predicate::AlwaysFalse.or(Predicate::AlwaysFalse);
+
+        let mut test_evaluator = TestEvaluator {};
+
+        let result = visit(&mut test_evaluator, &predicate);
+
+        assert!(!result.unwrap());
+
+        let predicate = Predicate::AlwaysTrue.or(Predicate::AlwaysTrue);
+
+        let mut test_evaluator = TestEvaluator {};
+
+        let result = visit(&mut test_evaluator, &predicate);
+
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn test_not() {
+        let predicate = Predicate::AlwaysFalse.not();
+
+        let mut test_evaluator = TestEvaluator {};
+
+        let result = visit(&mut test_evaluator, &predicate);
+
+        assert!(result.unwrap());
+
+        let predicate = Predicate::AlwaysTrue.not();
+
+        let mut test_evaluator = TestEvaluator {};
+
+        let result = visit(&mut test_evaluator, &predicate);
+
+        assert!(!result.unwrap());
+    }
+
+    #[test]
+    fn test_is_null() {
+        let predicate = Predicate::Unary(UnaryExpression::new(
+            PredicateOperator::IsNull,
+            Reference::new("c"),
+        ));
+
+        let mut test_evaluator = TestEvaluator {};
+
+        let result = visit(&mut test_evaluator, &predicate);
+
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn test_not_null() {
+        let predicate = Predicate::Unary(UnaryExpression::new(
+            PredicateOperator::NotNull,
+            Reference::new("a"),
+        ));
+
+        let mut test_evaluator = TestEvaluator {};
+
+        let result = visit(&mut test_evaluator, &predicate);
+
+        assert!(!result.unwrap());
+    }
+
+    #[test]
+    fn test_is_nan() {
+        let predicate = Predicate::Unary(UnaryExpression::new(
+            PredicateOperator::IsNan,
+            Reference::new("b"),
+        ));
+
+        let mut test_evaluator = TestEvaluator {};
+
+        let result = visit(&mut test_evaluator, &predicate);
+
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn test_not_nan() {
+        let predicate = Predicate::Unary(UnaryExpression::new(
+            PredicateOperator::NotNan,
+            Reference::new("b"),
+        ));
+
+        let mut test_evaluator = TestEvaluator {};
+
+        let result = visit(&mut test_evaluator, &predicate);
+
+        assert!(!result.unwrap());
+    }
+
+    #[test]
+    fn test_less_than() {
+        let predicate = Predicate::Binary(BinaryExpression::new(
+            PredicateOperator::LessThan,
+            Reference::new("a"),
+            Datum::int(10),
+        ));
+
+        let mut test_evaluator = TestEvaluator {};
+
+        let result = visit(&mut test_evaluator, &predicate);
+
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn test_less_than_or_eq() {
+        let predicate = Predicate::Binary(BinaryExpression::new(
+            PredicateOperator::LessThanOrEq,
+            Reference::new("a"),
+            Datum::int(10),
+        ));
+
+        let mut test_evaluator = TestEvaluator {};
+
+        let result = visit(&mut test_evaluator, &predicate);
+
+        assert!(!result.unwrap());
+    }
+
+    #[test]
+    fn test_greater_than() {
+        let predicate = Predicate::Binary(BinaryExpression::new(
+            PredicateOperator::GreaterThan,
+            Reference::new("a"),
+            Datum::int(10),
+        ));
+
+        let mut test_evaluator = TestEvaluator {};
+
+        let result = visit(&mut test_evaluator, &predicate);
+
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn test_greater_than_or_eq() {
+        let predicate = Predicate::Binary(BinaryExpression::new(
+            PredicateOperator::GreaterThanOrEq,
+            Reference::new("a"),
+            Datum::int(10),
+        ));
+
+        let mut test_evaluator = TestEvaluator {};
+
+        let result = visit(&mut test_evaluator, &predicate);
+
+        assert!(!result.unwrap());
+    }
+
+    #[test]
+    fn test_eq() {
+        let predicate = Predicate::Binary(BinaryExpression::new(
+            PredicateOperator::Eq,
+            Reference::new("a"),
+            Datum::int(10),
+        ));
+
+        let mut test_evaluator = TestEvaluator {};
+
+        let result = visit(&mut test_evaluator, &predicate);
+
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn test_not_eq() {
+        let predicate = Predicate::Binary(BinaryExpression::new(
+            PredicateOperator::NotEq,
+            Reference::new("a"),
+            Datum::int(10),
+        ));
+
+        let mut test_evaluator = TestEvaluator {};
+
+        let result = visit(&mut test_evaluator, &predicate);
+
+        assert!(!result.unwrap());
+    }
+
+    #[test]
+    fn test_starts_with() {
+        let predicate = Predicate::Binary(BinaryExpression::new(
+            PredicateOperator::StartsWith,
+            Reference::new("a"),
+            Datum::string("test"),
+        ));
+
+        let mut test_evaluator = TestEvaluator {};
+
+        let result = visit(&mut test_evaluator, &predicate);
+
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn test_not_starts_with() {
+        let predicate = Predicate::Binary(BinaryExpression::new(
+            PredicateOperator::NotStartsWith,
+            Reference::new("a"),
+            Datum::string("test"),
+        ));
+
+        let mut test_evaluator = TestEvaluator {};
+
+        let result = visit(&mut test_evaluator, &predicate);
+
+        assert!(!result.unwrap());
+    }
+
+    #[test]
+    fn test_in() {
+        let predicate = Predicate::Set(SetExpression::new(
+            PredicateOperator::In,
+            Reference::new("a"),
+            FnvHashSet::from_iter(vec![Datum::int(1)]),
+        ));
+
+        let mut test_evaluator = TestEvaluator {};
+
+        let result = visit(&mut test_evaluator, &predicate);
+
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn test_not_in() {
+        let predicate = Predicate::Set(SetExpression::new(
+            PredicateOperator::NotIn,
+            Reference::new("a"),
+            FnvHashSet::from_iter(vec![Datum::int(1)]),
+        ));
+
+        let mut test_evaluator = TestEvaluator {};
+
+        let result = visit(&mut test_evaluator, &predicate);
+
+        assert!(!result.unwrap());
+    }
+}

--- a/crates/iceberg/src/expr/visitors/rewrite_not.rs
+++ b/crates/iceberg/src/expr/visitors/rewrite_not.rs
@@ -18,8 +18,9 @@
 use fnv::FnvHashSet;
 
 use crate::Result;
+use crate::expr::visitors::bound_predicate_visitor::BoundPredicateVisitor;
 use crate::expr::visitors::predicate_visitor::PredicateVisitor;
-use crate::expr::{Predicate, Reference};
+use crate::expr::{BoundPredicate, BoundReference, Predicate, Reference};
 use crate::spec::Datum;
 
 /// A visitor that rewrites predicates by removing `NOT` predicates and
@@ -167,11 +168,175 @@ impl PredicateVisitor for RewriteNotVisitor {
     }
 }
 
+impl BoundPredicateVisitor for RewriteNotVisitor {
+    type T = BoundPredicate;
+
+    fn always_true(&mut self) -> Result<Self::T> {
+        Ok(BoundPredicate::AlwaysTrue)
+    }
+
+    fn always_false(&mut self) -> Result<Self::T> {
+        Ok(BoundPredicate::AlwaysFalse)
+    }
+
+    fn and(&mut self, lhs: Self::T, rhs: Self::T) -> Result<Self::T> {
+        Ok(lhs.and(rhs))
+    }
+
+    fn or(&mut self, lhs: Self::T, rhs: Self::T) -> Result<Self::T> {
+        Ok(lhs.or(rhs))
+    }
+
+    fn not(&mut self, inner: Self::T) -> Result<Self::T> {
+        // This is the key method: instead of creating a NOT predicate,
+        // we directly negate the inner predicate
+        Ok(inner.negate())
+    }
+
+    fn is_null(
+        &mut self,
+        _reference: &BoundReference,
+        predicate: &BoundPredicate,
+    ) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+
+    fn not_null(
+        &mut self,
+        _reference: &BoundReference,
+        predicate: &BoundPredicate,
+    ) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+
+    fn is_nan(
+        &mut self,
+        _reference: &BoundReference,
+        predicate: &BoundPredicate,
+    ) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+
+    fn not_nan(
+        &mut self,
+        _reference: &BoundReference,
+        predicate: &BoundPredicate,
+    ) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+
+    fn less_than(
+        &mut self,
+        _reference: &BoundReference,
+        _literal: &Datum,
+        predicate: &BoundPredicate,
+    ) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+
+    fn less_than_or_eq(
+        &mut self,
+        _reference: &BoundReference,
+        _literal: &Datum,
+        predicate: &BoundPredicate,
+    ) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+
+    fn greater_than(
+        &mut self,
+        _reference: &BoundReference,
+        _literal: &Datum,
+        predicate: &BoundPredicate,
+    ) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+
+    fn greater_than_or_eq(
+        &mut self,
+        _reference: &BoundReference,
+        _literal: &Datum,
+        predicate: &BoundPredicate,
+    ) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+
+    fn eq(
+        &mut self,
+        _reference: &BoundReference,
+        _literal: &Datum,
+        predicate: &BoundPredicate,
+    ) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+
+    fn not_eq(
+        &mut self,
+        _reference: &BoundReference,
+        _literal: &Datum,
+        predicate: &BoundPredicate,
+    ) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+
+    fn starts_with(
+        &mut self,
+        _reference: &BoundReference,
+        _literal: &Datum,
+        predicate: &BoundPredicate,
+    ) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+
+    fn not_starts_with(
+        &mut self,
+        _reference: &BoundReference,
+        _literal: &Datum,
+        predicate: &BoundPredicate,
+    ) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+
+    fn r#in(
+        &mut self,
+        _reference: &BoundReference,
+        _literals: &FnvHashSet<Datum>,
+        predicate: &BoundPredicate,
+    ) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+
+    fn not_in(
+        &mut self,
+        _reference: &BoundReference,
+        _literals: &FnvHashSet<Datum>,
+        predicate: &BoundPredicate,
+    ) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::ops::Not;
+    use std::sync::Arc;
 
     use super::*;
+    use crate::expr::Bind;
+    use crate::spec::{NestedField, PrimitiveType, Schema, SchemaRef, Type};
+
+    fn create_test_schema() -> SchemaRef {
+        Arc::new(
+            Schema::builder()
+                .with_schema_id(1)
+                .with_fields(vec![
+                    NestedField::required(1, "bar", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::optional(2, "foo", Type::Primitive(PrimitiveType::String)).into(),
+                ])
+                .build()
+                .unwrap(),
+        )
+    }
 
     #[test]
     fn test_rewrite_not_deeply_nested() {
@@ -196,5 +361,44 @@ mod tests {
 
         let result_str = format!("{result}");
         assert_eq!(&result_str, "((bar >= 40) AND (bar < 40)) OR (bar >= 40)");
+    }
+
+    #[test]
+    fn test_bound_predicate_rewrite_not() {
+        let schema = create_test_schema();
+
+        // Test NOT elimination on bound predicates
+        let predicate = Reference::new("bar").less_than(Datum::int(40)).not();
+        let bound_predicate = predicate.bind(schema.clone(), true).unwrap();
+        let result = bound_predicate.rewrite_not();
+
+        // The result should be bar >= 40
+        let expected_predicate = Reference::new("bar").greater_than_or_equal_to(Datum::int(40));
+        let expected_bound = expected_predicate.bind(schema, true).unwrap();
+
+        assert_eq!(result, expected_bound);
+    }
+
+    #[test]
+    fn test_bound_predicate_and_or_rewrite_not() {
+        let schema = create_test_schema();
+
+        // Test De Morgan's law: NOT(A AND B) = (NOT A) OR (NOT B)
+        let predicate = Reference::new("bar")
+            .less_than(Datum::int(10))
+            .and(Reference::new("foo").is_null())
+            .not();
+
+        let bound_predicate = predicate.bind(schema.clone(), true).unwrap();
+        let result = bound_predicate.rewrite_not();
+
+        // Expected: (bar >= 10) OR (foo IS NOT NULL)
+        let expected_predicate = Reference::new("bar")
+            .greater_than_or_equal_to(Datum::int(10))
+            .or(Reference::new("foo").is_not_null());
+
+        let expected_bound = expected_predicate.bind(schema, true).unwrap();
+
+        assert_eq!(result, expected_bound);
     }
 }

--- a/crates/iceberg/src/expr/visitors/rewrite_not.rs
+++ b/crates/iceberg/src/expr/visitors/rewrite_not.rs
@@ -1,0 +1,200 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use fnv::FnvHashSet;
+
+use crate::Result;
+use crate::expr::visitors::predicate_visitor::PredicateVisitor;
+use crate::expr::{Predicate, Reference};
+use crate::spec::Datum;
+
+/// A visitor that rewrites predicates by removing `NOT` predicates and
+/// directly negating the inner expressions instead. This applies logical
+/// laws (such as De Morgan's laws) to recursively negate and simplify
+/// inner expressions within `NOT` predicates.
+pub struct RewriteNotVisitor;
+
+impl RewriteNotVisitor {
+    /// Creates a new `RewriteNotVisitor`
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl PredicateVisitor for RewriteNotVisitor {
+    type T = Predicate;
+
+    fn always_true(&mut self) -> Result<Self::T> {
+        Ok(Predicate::AlwaysTrue)
+    }
+
+    fn always_false(&mut self) -> Result<Self::T> {
+        Ok(Predicate::AlwaysFalse)
+    }
+
+    fn and(&mut self, lhs: Self::T, rhs: Self::T) -> Result<Self::T> {
+        Ok(lhs.and(rhs))
+    }
+
+    fn or(&mut self, lhs: Self::T, rhs: Self::T) -> Result<Self::T> {
+        Ok(lhs.or(rhs))
+    }
+
+    fn not(&mut self, inner: Self::T) -> Result<Self::T> {
+        // This is the key method: instead of creating a NOT predicate,
+        // we directly negate the inner predicate
+        Ok(inner.negate())
+    }
+
+    fn is_null(&mut self, _reference: &Reference, predicate: &Predicate) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+
+    fn not_null(&mut self, _reference: &Reference, predicate: &Predicate) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+
+    fn is_nan(&mut self, _reference: &Reference, predicate: &Predicate) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+
+    fn not_nan(&mut self, _reference: &Reference, predicate: &Predicate) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+
+    fn less_than(
+        &mut self,
+        _reference: &Reference,
+        _literal: &Datum,
+        predicate: &Predicate,
+    ) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+
+    fn less_than_or_eq(
+        &mut self,
+        _reference: &Reference,
+        _literal: &Datum,
+        predicate: &Predicate,
+    ) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+
+    fn greater_than(
+        &mut self,
+        _reference: &Reference,
+        _literal: &Datum,
+        predicate: &Predicate,
+    ) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+
+    fn greater_than_or_eq(
+        &mut self,
+        _reference: &Reference,
+        _literal: &Datum,
+        predicate: &Predicate,
+    ) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+
+    fn eq(
+        &mut self,
+        _reference: &Reference,
+        _literal: &Datum,
+        predicate: &Predicate,
+    ) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+
+    fn not_eq(
+        &mut self,
+        _reference: &Reference,
+        _literal: &Datum,
+        predicate: &Predicate,
+    ) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+
+    fn starts_with(
+        &mut self,
+        _reference: &Reference,
+        _literal: &Datum,
+        predicate: &Predicate,
+    ) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+
+    fn not_starts_with(
+        &mut self,
+        _reference: &Reference,
+        _literal: &Datum,
+        predicate: &Predicate,
+    ) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+
+    fn r#in(
+        &mut self,
+        _reference: &Reference,
+        _literals: &FnvHashSet<Datum>,
+        predicate: &Predicate,
+    ) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+
+    fn not_in(
+        &mut self,
+        _reference: &Reference,
+        _literals: &FnvHashSet<Datum>,
+        predicate: &Predicate,
+    ) -> Result<Self::T> {
+        Ok(predicate.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Not;
+
+    use super::*;
+
+    #[test]
+    fn test_rewrite_not_deeply_nested() {
+        // Test nested expression: not((not((not(ref(name="bar") < 40) and ref(name="bar") < 40)) and ref(name="bar") < 40))
+        // Expected rewrite not result: ((bar >= 40) AND (bar < 40)) OR (bar >= 40)
+        let complex_expression = Reference::new("bar")
+            .less_than(Datum::int(40))
+            .not()
+            .and(Reference::new("bar").less_than(Datum::int(40)))
+            .not()
+            .and(Reference::new("bar").less_than(Datum::int(40)))
+            .not();
+
+        let expected = Reference::new("bar")
+            .greater_than_or_equal_to(Datum::int(40))
+            .and(Reference::new("bar").less_than(Datum::int(40)))
+            .or(Reference::new("bar").greater_than_or_equal_to(Datum::int(40)));
+
+        let result = complex_expression.rewrite_not();
+
+        assert_eq!(result, expected);
+
+        let result_str = format!("{result}");
+        assert_eq!(&result_str, "((bar >= 40) AND (bar < 40)) OR (bar >= 40)");
+    }
+}

--- a/crates/iceberg/src/io/object_cache.rs
+++ b/crates/iceberg/src/io/object_cache.rs
@@ -266,7 +266,7 @@ mod tests {
             let mut writer = ManifestWriterBuilder::new(
                 self.next_manifest_file(),
                 Some(current_snapshot.snapshot_id()),
-                vec![],
+                None,
                 current_schema.clone(),
                 current_partition_spec.as_ref().clone(),
             )

--- a/crates/iceberg/src/io/storage_azdls.rs
+++ b/crates/iceberg/src/io/storage_azdls.rs
@@ -49,6 +49,11 @@ pub const ADLS_CLIENT_ID: &str = "adls.client-id";
 /// The client-secret.
 pub const ADLS_CLIENT_SECRET: &str = "adls.client-secret";
 
+/// The authority host of the service principal.
+/// - required for client_credentials authentication
+/// - default value: `https://login.microsoftonline.com`
+pub const ADLS_AUTHORITY_HOST: &str = "adls.authority-host";
+
 /// Parses adls.* prefixed configuration properties.
 pub(crate) fn azdls_config_parse(mut properties: HashMap<String, String>) -> Result<AzdlsConfig> {
     let mut config = AzdlsConfig::default();
@@ -82,6 +87,10 @@ pub(crate) fn azdls_config_parse(mut properties: HashMap<String, String>) -> Res
 
     if let Some(client_secret) = properties.remove(ADLS_CLIENT_SECRET) {
         config.client_secret = Some(client_secret);
+    }
+
+    if let Some(authority_host) = properties.remove(ADLS_AUTHORITY_HOST) {
+        config.authority_host = Some(authority_host);
     }
 
     Ok(config)

--- a/crates/iceberg/src/io/storage_s3.rs
+++ b/crates/iceberg/src/io/storage_s3.rs
@@ -65,6 +65,16 @@ pub const S3_ALLOW_ANONYMOUS: &str = "s3.allow-anonymous";
 pub const S3_DISABLE_EC2_METADATA: &str = "s3.disable-ec2-metadata";
 /// Option to skip loading configuration from config file and the env.
 pub const S3_DISABLE_CONFIG_LOAD: &str = "s3.disable-config-load";
+/// Option to enable remote signing.
+pub const S3_REMOTE_SIGNING_ENABLED: &str = "s3.remote-signing-enabled";
+/// Option to set the signer to use for remote signing.
+pub const S3_SIGNER: &str = "s3.signer";
+/// Option to set the signer URI to use for remote signing.
+pub const S3_SIGNER_URI: &str = "s3.signer.uri";
+/// Option to set the signer endpoint to use for remote signing.
+pub const S3_SIGNER_ENDPOINT: &str = "s3.signer.endpoint";
+/// Option to set the signer token to use for remote signing.
+pub const TOKEN: &str = "token";
 
 /// Parse iceberg props to s3 config.
 pub(crate) fn s3_config_parse(mut m: HashMap<String, String>) -> Result<S3Config> {
@@ -146,6 +156,24 @@ pub(crate) fn s3_config_parse(mut m: HashMap<String, String>) -> Result<S3Config
             cfg.disable_config_load = true;
         }
     };
+
+    if let Some(remote_signing_enabled) = m.remove(S3_REMOTE_SIGNING_ENABLED) {
+        if is_truthy(remote_signing_enabled.to_lowercase().as_str()) {
+            cfg.remote_signing_enabled = true;
+        }
+    }
+    if let Some(signer) = m.remove(S3_SIGNER) {
+        cfg.signer = Some(signer);
+    }
+    if let Some(signer_uri) = m.remove(S3_SIGNER_URI) {
+        cfg.signer_uri = Some(signer_uri);
+    }
+    if let Some(signer_endpoint) = m.remove(S3_SIGNER_ENDPOINT) {
+        cfg.signer_endpoint = Some(signer_endpoint);
+    }
+    if let Some(token) = m.remove(TOKEN) {
+        cfg.token = Some(token);
+    }
 
     Ok(cfg)
 }

--- a/crates/iceberg/src/scan/cache.rs
+++ b/crates/iceberg/src/scan/cache.rs
@@ -155,7 +155,7 @@ impl ManifestEvaluatorCache {
             .unwrap()
             .insert(
                 spec_id,
-                Arc::new(ManifestEvaluator::new(partition_filter.as_ref().clone())),
+                Arc::new(ManifestEvaluator::builder(partition_filter.as_ref().clone()).build()),
             );
 
         let read = self

--- a/crates/iceberg/src/scan/mod.rs
+++ b/crates/iceberg/src/scan/mod.rs
@@ -752,7 +752,7 @@ pub mod tests {
             let mut writer = ManifestWriterBuilder::new(
                 self.next_manifest_file(),
                 Some(current_snapshot.snapshot_id()),
-                vec![],
+                None,
                 current_schema.clone(),
                 current_partition_spec.as_ref().clone(),
             )
@@ -964,7 +964,7 @@ pub mod tests {
             let mut writer = ManifestWriterBuilder::new(
                 self.next_manifest_file(),
                 Some(current_snapshot.snapshot_id()),
-                vec![],
+                None,
                 current_schema.clone(),
                 current_partition_spec.as_ref().clone(),
             )

--- a/crates/iceberg/src/spec/manifest/mod.rs
+++ b/crates/iceberg/src/spec/manifest/mod.rs
@@ -232,7 +232,7 @@ mod tests {
         let mut writer = ManifestWriterBuilder::new(
             output_file,
             Some(1),
-            vec![],
+            None,
             metadata.schema.clone(),
             metadata.partition_spec.clone(),
         )
@@ -417,7 +417,7 @@ mod tests {
         let mut writer = ManifestWriterBuilder::new(
             output_file,
             Some(2),
-            vec![],
+            None,
             metadata.schema.clone(),
             metadata.partition_spec.clone(),
         )
@@ -514,7 +514,7 @@ mod tests {
         let mut writer = ManifestWriterBuilder::new(
             output_file,
             Some(3),
-            vec![],
+            None,
             metadata.schema.clone(),
             metadata.partition_spec.clone(),
         )
@@ -623,7 +623,7 @@ mod tests {
         let mut writer = ManifestWriterBuilder::new(
             output_file,
             Some(2),
-            vec![],
+            None,
             metadata.schema.clone(),
             metadata.partition_spec.clone(),
         )
@@ -731,7 +731,7 @@ mod tests {
         let mut writer = ManifestWriterBuilder::new(
             output_file,
             Some(2),
-            vec![],
+            None,
             metadata.schema.clone(),
             metadata.partition_spec.clone(),
         )
@@ -1010,7 +1010,7 @@ mod tests {
         let mut writer = ManifestWriterBuilder::new(
             output_file,
             Some(1),
-            vec![],
+            None,
             metadata.schema.clone(),
             metadata.partition_spec.clone(),
         )

--- a/crates/iceberg/src/spec/manifest/writer.rs
+++ b/crates/iceberg/src/spec/manifest/writer.rs
@@ -40,7 +40,7 @@ use crate::{Error, ErrorKind};
 pub struct ManifestWriterBuilder {
     output: OutputFile,
     snapshot_id: Option<i64>,
-    key_metadata: Vec<u8>,
+    key_metadata: Option<Vec<u8>>,
     schema: SchemaRef,
     partition_spec: PartitionSpec,
 }
@@ -50,7 +50,7 @@ impl ManifestWriterBuilder {
     pub fn new(
         output: OutputFile,
         snapshot_id: Option<i64>,
-        key_metadata: Vec<u8>,
+        key_metadata: Option<Vec<u8>>,
         schema: SchemaRef,
         partition_spec: PartitionSpec,
     ) -> Self {
@@ -115,7 +115,7 @@ pub struct ManifestWriter {
 
     min_seq_num: Option<i64>,
 
-    key_metadata: Vec<u8>,
+    key_metadata: Option<Vec<u8>>,
 
     manifest_entries: Vec<ManifestEntry>,
 
@@ -127,7 +127,7 @@ impl ManifestWriter {
     pub(crate) fn new(
         output: OutputFile,
         snapshot_id: Option<i64>,
-        key_metadata: Vec<u8>,
+        key_metadata: Option<Vec<u8>>,
         metadata: ManifestMetadata,
     ) -> Self {
         Self {
@@ -416,7 +416,7 @@ impl ManifestWriter {
             existing_rows_count: Some(self.existing_rows),
             deleted_rows_count: Some(self.deleted_rows),
             partitions: Some(partition_summary),
-            key_metadata: Some(self.key_metadata),
+            key_metadata: self.key_metadata,
         })
     }
 }
@@ -622,7 +622,7 @@ mod tests {
         let mut writer = ManifestWriterBuilder::new(
             output_file,
             Some(3),
-            vec![],
+            None,
             metadata.schema.clone(),
             metadata.partition_spec.clone(),
         )

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -227,6 +227,18 @@ impl TableMetadata {
         }
     }
 
+    /// Returns the last column id.
+    #[inline]
+    pub fn last_column_id(&self) -> i32 {
+        self.last_column_id
+    }
+
+    /// Returns the last partition_id
+    #[inline]
+    pub fn last_partition_id(&self) -> i32 {
+        self.last_partition_id
+    }
+
     /// Returns last updated time.
     #[inline]
     pub fn last_updated_timestamp(&self) -> Result<DateTime<Utc>> {

--- a/crates/iceberg/src/table.rs
+++ b/crates/iceberg/src/table.rs
@@ -162,8 +162,10 @@ pub struct Table {
 }
 
 impl Table {
-    pub(crate) fn with_metadata(&mut self, metadata: TableMetadataRef) {
+    /// Sets the [`Table`] metadata and returns an updated instance with the new metadata applied.
+    pub(crate) fn with_metadata(mut self, metadata: TableMetadataRef) -> Self {
         self.metadata = metadata;
+        self
     }
 
     /// Returns a TableBuilder to build a table

--- a/crates/iceberg/src/transaction/append.rs
+++ b/crates/iceberg/src/transaction/append.rs
@@ -33,7 +33,6 @@ use crate::transaction::{ActionCommit, TransactionAction};
 pub struct FastAppendAction {
     check_duplicate: bool,
     // below are properties used to create SnapshotProducer when commit
-    snapshot_id: i64,
     commit_uuid: Option<Uuid>,
     key_metadata: Option<Vec<u8>>,
     snapshot_properties: HashMap<String, String>,
@@ -41,10 +40,9 @@ pub struct FastAppendAction {
 }
 
 impl FastAppendAction {
-    pub(crate) fn new(snapshot_id: i64) -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             check_duplicate: true,
-            snapshot_id,
             commit_uuid: None,
             key_metadata: None,
             snapshot_properties: HashMap::default(),
@@ -95,7 +93,7 @@ impl TransactionAction for FastAppendAction {
         }
 
         let snapshot_producer = SnapshotProducer::new(
-            self.snapshot_id,
+            table,
             self.commit_uuid.unwrap_or_else(Uuid::now_v7),
             self.key_metadata.clone(),
             self.snapshot_properties.clone(),

--- a/crates/iceberg/src/transaction/append.rs
+++ b/crates/iceberg/src/transaction/append.rs
@@ -15,44 +15,41 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+use std::sync::Arc;
 
+use async_trait::async_trait;
 use uuid::Uuid;
 
 use crate::error::Result;
 use crate::spec::{DataFile, ManifestEntry, ManifestFile, Operation};
-use crate::transaction::Transaction;
+use crate::table::Table;
 use crate::transaction::snapshot::{
-    DefaultManifestProcess, SnapshotProduceAction, SnapshotProduceOperation,
+    DefaultManifestProcess, SnapshotProduceOperation, SnapshotProducer,
 };
-use crate::writer::file_writer::ParquetWriter;
-use crate::{Error, ErrorKind};
+use crate::transaction::{ActionCommit, TransactionAction};
 
 /// FastAppendAction is a transaction action for fast append data files to the table.
 pub struct FastAppendAction {
-    snapshot_produce_action: SnapshotProduceAction,
     check_duplicate: bool,
+    // below are properties used to create SnapshotProducer when commit
+    snapshot_id: i64,
+    commit_uuid: Option<Uuid>,
+    key_metadata: Option<Vec<u8>>,
+    snapshot_properties: HashMap<String, String>,
+    added_data_files: Vec<DataFile>,
 }
 
 impl FastAppendAction {
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn new(
-        tx: Transaction,
-        snapshot_id: i64,
-        commit_uuid: Uuid,
-        key_metadata: Vec<u8>,
-        snapshot_properties: HashMap<String, String>,
-    ) -> Result<Self> {
-        Ok(Self {
-            snapshot_produce_action: SnapshotProduceAction::new(
-                tx,
-                snapshot_id,
-                key_metadata,
-                commit_uuid,
-                snapshot_properties,
-            )?,
+    pub(crate) fn new(snapshot_id: i64) -> Self {
+        Self {
             check_duplicate: true,
-        })
+            snapshot_id,
+            commit_uuid: None,
+            key_metadata: None,
+            snapshot_properties: HashMap::default(),
+            added_data_files: vec![],
+        }
     }
 
     /// Set whether to check duplicate files
@@ -62,101 +59,51 @@ impl FastAppendAction {
     }
 
     /// Add data files to the snapshot.
-    pub fn add_data_files(
-        &mut self,
-        data_files: impl IntoIterator<Item = DataFile>,
-    ) -> Result<&mut Self> {
-        self.snapshot_produce_action.add_data_files(data_files)?;
-        Ok(self)
+    pub fn add_data_files(mut self, data_files: impl IntoIterator<Item = DataFile>) -> Self {
+        self.added_data_files.extend(data_files);
+        self
+    }
+
+    /// Set commit UUID for the snapshot.
+    pub fn set_commit_uuid(mut self, commit_uuid: Uuid) -> Self {
+        self.commit_uuid = Some(commit_uuid);
+        self
+    }
+
+    /// Set key metadata for manifest files.
+    pub fn set_key_metadata(mut self, key_metadata: Vec<u8>) -> Self {
+        self.key_metadata = Some(key_metadata);
+        self
     }
 
     /// Set snapshot summary properties.
-    pub fn set_snapshot_properties(
-        &mut self,
-        snapshot_properties: HashMap<String, String>,
-    ) -> Result<&mut Self> {
-        self.snapshot_produce_action
-            .set_snapshot_properties(snapshot_properties)?;
-        Ok(self)
+    pub fn set_snapshot_properties(mut self, snapshot_properties: HashMap<String, String>) -> Self {
+        self.snapshot_properties = snapshot_properties;
+        self
     }
+}
 
-    /// Adds existing parquet files
-    ///
-    /// Note: This API is not yet fully supported in version 0.5.x.  
-    /// It is currently incomplete and should not be used in production.
-    /// Specifically, schema compatibility checks and support for adding to partitioned tables
-    /// have not yet been implemented.
-    #[allow(dead_code)]
-    async fn add_parquet_files(mut self, file_path: Vec<String>) -> Result<Transaction> {
-        if !self
-            .snapshot_produce_action
-            .tx
-            .current_table
-            .metadata()
-            .default_spec
-            .is_unpartitioned()
-        {
-            return Err(Error::new(
-                ErrorKind::FeatureUnsupported,
-                "Appending to partitioned tables is not supported",
-            ));
-        }
+#[async_trait]
+impl TransactionAction for FastAppendAction {
+    async fn commit(self: Arc<Self>, table: &Table) -> Result<ActionCommit> {
+        // validate added files
+        SnapshotProducer::validate_added_data_files(table, &self.added_data_files)?;
 
-        let table_metadata = self.snapshot_produce_action.tx.current_table.metadata();
-
-        let data_files = ParquetWriter::parquet_files_to_data_files(
-            self.snapshot_produce_action.tx.current_table.file_io(),
-            file_path,
-            table_metadata,
-        )
-        .await?;
-
-        self.add_data_files(data_files)?;
-
-        self.apply().await
-    }
-
-    /// Finished building the action and apply it to the transaction.
-    pub async fn apply(self) -> Result<Transaction> {
         // Checks duplicate files
         if self.check_duplicate {
-            let new_files: HashSet<&str> = self
-                .snapshot_produce_action
-                .added_data_files
-                .iter()
-                .map(|df| df.file_path.as_str())
-                .collect();
-
-            let mut referenced_files = Vec::new();
-            let table = &self.snapshot_produce_action.tx.current_table;
-            if let Some(current_snapshot) = table.metadata().current_snapshot() {
-                let manifest_list = current_snapshot
-                    .load_manifest_list(table.file_io(), &table.metadata_ref())
-                    .await?;
-                for manifest_list_entry in manifest_list.entries() {
-                    let manifest = manifest_list_entry.load_manifest(table.file_io()).await?;
-                    for entry in manifest.entries() {
-                        let file_path = entry.file_path();
-                        if new_files.contains(file_path) && entry.is_alive() {
-                            referenced_files.push(file_path.to_string());
-                        }
-                    }
-                }
-            }
-
-            if !referenced_files.is_empty() {
-                return Err(Error::new(
-                    ErrorKind::DataInvalid,
-                    format!(
-                        "Cannot add files that are already referenced by table, files: {}",
-                        referenced_files.join(", ")
-                    ),
-                ));
-            }
+            SnapshotProducer::validate_duplicate_files(table, &self.added_data_files).await?;
         }
 
-        self.snapshot_produce_action
-            .apply(FastAppendOperation, DefaultManifestProcess)
+        let snapshot_producer = SnapshotProducer::new(
+            self.snapshot_id,
+            self.commit_uuid.unwrap_or_else(Uuid::now_v7),
+            self.key_metadata.clone(),
+            self.snapshot_properties.clone(),
+            self.added_data_files.clone(),
+        );
+
+        snapshot_producer
+            .commit(table, FastAppendOperation, DefaultManifestProcess)
             .await
     }
 }
@@ -170,29 +117,18 @@ impl SnapshotProduceOperation for FastAppendOperation {
 
     async fn delete_entries(
         &self,
-        _snapshot_produce: &SnapshotProduceAction,
+        _snapshot_produce: &SnapshotProducer,
     ) -> Result<Vec<ManifestEntry>> {
         Ok(vec![])
     }
 
-    async fn existing_manifest(
-        &self,
-        snapshot_produce: &SnapshotProduceAction,
-    ) -> Result<Vec<ManifestFile>> {
-        let Some(snapshot) = snapshot_produce
-            .tx
-            .current_table
-            .metadata()
-            .current_snapshot()
-        else {
+    async fn existing_manifest(&self, table: &Table) -> Result<Vec<ManifestFile>> {
+        let Some(snapshot) = table.metadata().current_snapshot() else {
             return Ok(vec![]);
         };
 
         let manifest_list = snapshot
-            .load_manifest_list(
-                snapshot_produce.tx.current_table.file_io(),
-                &snapshot_produce.tx.current_table.metadata_ref(),
-            )
+            .load_manifest_list(table.file_io(), &table.metadata_ref())
             .await?;
 
         Ok(manifest_list
@@ -207,33 +143,31 @@ impl SnapshotProduceOperation for FastAppendOperation {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::sync::Arc;
 
-    use crate::scan::tests::TableTestFixture;
     use crate::spec::{
         DataContentType, DataFileBuilder, DataFileFormat, Literal, MAIN_BRANCH, Struct,
     };
-    use crate::transaction::Transaction;
     use crate::transaction::tests::make_v2_minimal_table;
+    use crate::transaction::{Transaction, TransactionAction};
     use crate::{TableRequirement, TableUpdate};
 
     #[tokio::test]
     async fn test_empty_data_append_action() {
         let table = make_v2_minimal_table();
         let tx = Transaction::new(&table);
-        let mut action = tx.fast_append(None, vec![]).unwrap();
-        action.add_data_files(vec![]).unwrap();
-        assert!(action.apply().await.is_err());
+        let action = tx.fast_append().add_data_files(vec![]);
+        assert!(Arc::new(action).commit(&table).await.is_err());
     }
 
     #[tokio::test]
     async fn test_set_snapshot_properties() {
         let table = make_v2_minimal_table();
         let tx = Transaction::new(&table);
-        let mut action = tx.fast_append(None, vec![]).unwrap();
 
         let mut snapshot_properties = HashMap::new();
         snapshot_properties.insert("key".to_string(), "val".to_string());
-        action.set_snapshot_properties(snapshot_properties).unwrap();
+
         let data_file = DataFileBuilder::default()
             .content(DataContentType::Data)
             .file_path("test/1.parquet".to_string())
@@ -244,11 +178,16 @@ mod tests {
             .partition(Struct::from_iter([Some(Literal::long(300))]))
             .build()
             .unwrap();
-        action.add_data_files(vec![data_file]).unwrap();
-        let tx = action.apply().await.unwrap();
+
+        let action = tx
+            .fast_append()
+            .set_snapshot_properties(snapshot_properties)
+            .add_data_files(vec![data_file]);
+        let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
+        let updates = action_commit.take_updates();
 
         // Check customized properties is contained in snapshot summary properties.
-        let new_snapshot = if let TableUpdate::AddSnapshot { snapshot } = &tx.updates[0] {
+        let new_snapshot = if let TableUpdate::AddSnapshot { snapshot } = &updates[0] {
             snapshot
         } else {
             unreachable!()
@@ -264,10 +203,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_fast_append_action() {
+    async fn test_fast_append_file_with_incompatible_partition_value() {
         let table = make_v2_minimal_table();
         let tx = Transaction::new(&table);
-        let mut action = tx.fast_append(None, vec![]).unwrap();
+        let action = tx.fast_append();
 
         // check add data file with incompatible partition value
         let data_file = DataFileBuilder::default()
@@ -280,7 +219,17 @@ mod tests {
             .partition(Struct::from_iter([Some(Literal::string("test"))]))
             .build()
             .unwrap();
-        assert!(action.add_data_files(vec![data_file.clone()]).is_err());
+
+        let action = action.add_data_files(vec![data_file.clone()]);
+
+        assert!(Arc::new(action).commit(&table).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_fast_append() {
+        let table = make_v2_minimal_table();
+        let tx = Transaction::new(&table);
+        let action = tx.fast_append();
 
         let data_file = DataFileBuilder::default()
             .content(DataContentType::Data)
@@ -292,12 +241,15 @@ mod tests {
             .partition(Struct::from_iter([Some(Literal::long(300))]))
             .build()
             .unwrap();
-        action.add_data_files(vec![data_file.clone()]).unwrap();
-        let tx = action.apply().await.unwrap();
+
+        let action = action.add_data_files(vec![data_file.clone()]);
+        let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
+        let updates = action_commit.take_updates();
+        let requirements = action_commit.take_requirements();
 
         // check updates and requirements
         assert!(
-            matches!((&tx.updates[0],&tx.updates[1]), (TableUpdate::AddSnapshot { snapshot },TableUpdate::SetSnapshotRef { reference,ref_name }) if snapshot.snapshot_id() == reference.snapshot_id && ref_name == MAIN_BRANCH)
+            matches!((&updates[0],&updates[1]), (TableUpdate::AddSnapshot { snapshot },TableUpdate::SetSnapshotRef { reference,ref_name }) if snapshot.snapshot_id() == reference.snapshot_id && ref_name == MAIN_BRANCH)
         );
         assert_eq!(
             vec![
@@ -309,11 +261,11 @@ mod tests {
                     snapshot_id: table.metadata().current_snapshot_id
                 }
             ],
-            tx.requirements
+            requirements
         );
 
         // check manifest list
-        let new_snapshot = if let TableUpdate::AddSnapshot { snapshot } = &tx.updates[0] {
+        let new_snapshot = if let TableUpdate::AddSnapshot { snapshot } = &updates[0] {
             snapshot
         } else {
             unreachable!()
@@ -346,42 +298,5 @@ mod tests {
             manifest.entries()[0].snapshot_id().unwrap()
         );
         assert_eq!(data_file, *manifest.entries()[0].data_file());
-    }
-
-    #[tokio::test]
-    async fn test_add_duplicated_parquet_files_to_unpartitioned_table() {
-        let mut fixture = TableTestFixture::new_unpartitioned();
-        fixture.setup_unpartitioned_manifest_files().await;
-        let tx = crate::transaction::Transaction::new(&fixture.table);
-
-        let file_paths = vec![
-            format!("{}/1.parquet", &fixture.table_location),
-            format!("{}/3.parquet", &fixture.table_location),
-        ];
-
-        let fast_append_action = tx.fast_append(None, vec![]).unwrap();
-
-        // Attempt to add duplicated Parquet files with fast append.
-        assert!(
-            fast_append_action
-                .add_parquet_files(file_paths.clone())
-                .await
-                .is_err(),
-            "file already in table"
-        );
-
-        let file_paths = vec![format!("{}/2.parquet", &fixture.table_location)];
-
-        let tx = crate::transaction::Transaction::new(&fixture.table);
-        let fast_append_action = tx.fast_append(None, vec![]).unwrap();
-
-        // Attempt to add Parquet file which was deleted from table.
-        assert!(
-            fast_append_action
-                .add_parquet_files(file_paths.clone())
-                .await
-                .is_ok(),
-            "file not in table"
-        );
     }
 }

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -28,7 +28,6 @@ mod update_location;
 mod update_properties;
 mod upgrade_format_version;
 
-use std::collections::HashMap;
 use std::mem::discriminant;
 use std::sync::Arc;
 
@@ -142,19 +141,8 @@ impl Transaction {
     }
 
     /// Creates a fast append action.
-    pub fn fast_append(
-        self,
-        commit_uuid: Option<Uuid>,
-        key_metadata: Vec<u8>,
-    ) -> Result<FastAppendAction> {
-        let snapshot_id = self.generate_unique_snapshot_id();
-        FastAppendAction::new(
-            self,
-            snapshot_id,
-            commit_uuid.unwrap_or_else(Uuid::now_v7),
-            key_metadata,
-            HashMap::new(),
-        )
+    pub fn fast_append(&self) -> FastAppendAction {
+        FastAppendAction::new(self.generate_unique_snapshot_id())
     }
 
     /// Creates replace sort order action.

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -17,26 +17,32 @@
 
 //! This module contains transaction api.
 
+/// The `ApplyTransactionAction` trait provides an `apply` method
+/// that allows users to apply a transaction action to a `Transaction`.
 mod action;
+pub use action::*;
 mod append;
 mod snapshot;
 mod sort_order;
+mod update_location;
+mod update_properties;
+mod upgrade_format_version;
 
-use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::mem::discriminant;
 use std::sync::Arc;
 
 use uuid::Uuid;
 
-use crate::TableUpdate::UpgradeFormatVersion;
 use crate::error::Result;
-use crate::spec::FormatVersion;
 use crate::table::Table;
 use crate::transaction::action::BoxedTransactionAction;
 use crate::transaction::append::FastAppendAction;
 use crate::transaction::sort_order::ReplaceSortOrderAction;
-use crate::{Catalog, Error, ErrorKind, TableCommit, TableRequirement, TableUpdate};
+use crate::transaction::update_location::UpdateLocationAction;
+use crate::transaction::update_properties::UpdatePropertiesAction;
+use crate::transaction::upgrade_format_version::UpgradeFormatVersionAction;
+use crate::{Catalog, TableCommit, TableRequirement, TableUpdate};
 
 /// Table transaction.
 pub struct Transaction {
@@ -104,32 +110,13 @@ impl Transaction {
     }
 
     /// Sets table to a new version.
-    pub fn upgrade_table_version(mut self, format_version: FormatVersion) -> Result<Self> {
-        let current_version = self.current_table.metadata().format_version();
-        match current_version.cmp(&format_version) {
-            Ordering::Greater => {
-                return Err(Error::new(
-                    ErrorKind::DataInvalid,
-                    format!(
-                        "Cannot downgrade table version from {} to {}",
-                        current_version, format_version
-                    ),
-                ));
-            }
-            Ordering::Less => {
-                self.apply(vec![UpgradeFormatVersion { format_version }], vec![])?;
-            }
-            Ordering::Equal => {
-                // Do nothing.
-            }
-        }
-        Ok(self)
+    pub fn upgrade_table_version(&self) -> UpgradeFormatVersionAction {
+        UpgradeFormatVersionAction::new()
     }
 
     /// Update table's property.
-    pub fn set_properties(mut self, props: HashMap<String, String>) -> Result<Self> {
-        self.apply(vec![TableUpdate::SetProperties { updates: props }], vec![])?;
-        Ok(self)
+    pub fn update_table_properties(&self) -> UpdatePropertiesAction {
+        UpdatePropertiesAction::new()
     }
 
     fn generate_unique_snapshot_id(&self) -> i64 {
@@ -178,27 +165,48 @@ impl Transaction {
         }
     }
 
-    /// Remove properties in table.
-    pub fn remove_properties(mut self, keys: Vec<String>) -> Result<Self> {
-        self.apply(
-            vec![TableUpdate::RemoveProperties { removals: keys }],
-            vec![],
-        )?;
-        Ok(self)
-    }
-
     /// Set the location of table
-    pub fn set_location(mut self, location: String) -> Result<Self> {
-        self.apply(vec![TableUpdate::SetLocation { location }], vec![])?;
-        Ok(self)
+    pub fn update_location(&self) -> UpdateLocationAction {
+        UpdateLocationAction::new()
     }
 
     /// Commit transaction.
-    pub async fn commit(self, catalog: &dyn Catalog) -> Result<Table> {
+    pub async fn commit(mut self, catalog: &dyn Catalog) -> Result<Table> {
+        if self.actions.is_empty() && self.updates.is_empty() {
+            // nothing to commit
+            return Ok(self.base_table.clone());
+        }
+
+        self.do_commit(catalog).await
+    }
+
+    async fn do_commit(&mut self, catalog: &dyn Catalog) -> Result<Table> {
+        let base_table_identifier = self.base_table.identifier().to_owned();
+
+        let refreshed = catalog.load_table(&base_table_identifier.clone()).await?;
+
+        if self.base_table.metadata() != refreshed.metadata()
+            || self.base_table.metadata_location() != refreshed.metadata_location()
+        {
+            // current base is stale, use refreshed as base and re-apply transaction actions
+            self.base_table = refreshed.clone();
+        }
+
+        let current_table = self.base_table.clone();
+
+        for action in self.actions.clone() {
+            let mut action_commit = action.commit(&current_table).await?;
+            // apply changes to current_table
+            self.apply(
+                action_commit.take_updates(),
+                action_commit.take_requirements(),
+            )?;
+        }
+
         let table_commit = TableCommit::builder()
-            .ident(self.base_table.identifier().clone())
-            .updates(self.updates)
-            .requirements(self.requirements)
+            .ident(base_table_identifier)
+            .updates(self.updates.clone())
+            .requirements(self.requirements.clone())
             .build();
 
         catalog.update_table(table_commit).await
@@ -207,17 +215,15 @@ impl Transaction {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
     use std::fs::File;
     use std::io::BufReader;
 
+    use crate::TableIdent;
     use crate::io::FileIOBuilder;
-    use crate::spec::{FormatVersion, TableMetadata};
+    use crate::spec::TableMetadata;
     use crate::table::Table;
-    use crate::transaction::Transaction;
-    use crate::{TableIdent, TableUpdate};
 
-    fn make_v1_table() -> Table {
+    pub fn make_v1_table() -> Table {
         let file = File::open(format!(
             "{}/testdata/table_metadata/{}",
             env!("CARGO_MANIFEST_DIR"),
@@ -272,110 +278,5 @@ mod tests {
             .file_io(FileIOBuilder::new("memory").build().unwrap())
             .build()
             .unwrap()
-    }
-
-    #[test]
-    fn test_upgrade_table_version_v1_to_v2() {
-        let table = make_v1_table();
-        let tx = Transaction::new(&table);
-        let tx = tx.upgrade_table_version(FormatVersion::V2).unwrap();
-
-        assert_eq!(
-            vec![TableUpdate::UpgradeFormatVersion {
-                format_version: FormatVersion::V2
-            }],
-            tx.updates
-        );
-    }
-
-    #[test]
-    fn test_upgrade_table_version_v2_to_v2() {
-        let table = make_v2_table();
-        let tx = Transaction::new(&table);
-        let tx = tx.upgrade_table_version(FormatVersion::V2).unwrap();
-
-        assert!(
-            tx.updates.is_empty(),
-            "Upgrade table to same version should not generate any updates"
-        );
-        assert!(
-            tx.requirements.is_empty(),
-            "Upgrade table to same version should not generate any requirements"
-        );
-    }
-
-    #[test]
-    fn test_downgrade_table_version() {
-        let table = make_v2_table();
-        let tx = Transaction::new(&table);
-        let tx = tx.upgrade_table_version(FormatVersion::V1);
-
-        assert!(tx.is_err(), "Downgrade table version should fail!");
-    }
-
-    #[test]
-    fn test_set_table_property() {
-        let table = make_v2_table();
-        let tx = Transaction::new(&table);
-        let tx = tx
-            .set_properties(HashMap::from([("a".to_string(), "b".to_string())]))
-            .unwrap();
-
-        assert_eq!(
-            vec![TableUpdate::SetProperties {
-                updates: HashMap::from([("a".to_string(), "b".to_string())])
-            }],
-            tx.updates
-        );
-    }
-
-    #[test]
-    fn test_remove_property() {
-        let table = make_v2_table();
-        let tx = Transaction::new(&table);
-        let tx = tx
-            .remove_properties(vec!["a".to_string(), "b".to_string()])
-            .unwrap();
-
-        assert_eq!(
-            vec![TableUpdate::RemoveProperties {
-                removals: vec!["a".to_string(), "b".to_string()]
-            }],
-            tx.updates
-        );
-    }
-
-    #[test]
-    fn test_set_location() {
-        let table = make_v2_table();
-        let tx = Transaction::new(&table);
-        let tx = tx
-            .set_location(String::from("s3://bucket/prefix/new_table"))
-            .unwrap();
-
-        assert_eq!(
-            vec![TableUpdate::SetLocation {
-                location: String::from("s3://bucket/prefix/new_table")
-            }],
-            tx.updates
-        )
-    }
-
-    #[tokio::test]
-    async fn test_transaction_apply_upgrade() {
-        let table = make_v1_table();
-        let tx = Transaction::new(&table);
-        // Upgrade v1 to v1, do nothing.
-        let tx = tx.upgrade_table_version(FormatVersion::V1).unwrap();
-        // Upgrade v1 to v2, success.
-        let tx = tx.upgrade_table_version(FormatVersion::V2).unwrap();
-        assert_eq!(
-            vec![TableUpdate::UpgradeFormatVersion {
-                format_version: FormatVersion::V2
-            }],
-            tx.updates
-        );
-        // Upgrade v2 to v1, return error.
-        assert!(tx.upgrade_table_version(FormatVersion::V1).is_err());
     }
 }

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -57,6 +57,7 @@ mod snapshot;
 mod sort_order;
 mod update_location;
 mod update_properties;
+mod update_statistics;
 mod upgrade_format_version;
 
 use std::sync::Arc;
@@ -68,6 +69,7 @@ use crate::transaction::append::FastAppendAction;
 use crate::transaction::sort_order::ReplaceSortOrderAction;
 use crate::transaction::update_location::UpdateLocationAction;
 use crate::transaction::update_properties::UpdatePropertiesAction;
+use crate::transaction::update_statistics::UpdateStatisticsAction;
 use crate::transaction::upgrade_format_version::UpgradeFormatVersionAction;
 use crate::{Catalog, TableCommit, TableRequirement, TableUpdate};
 
@@ -141,6 +143,11 @@ impl Transaction {
     /// Set the location of table
     pub fn update_location(&self) -> UpdateLocationAction {
         UpdateLocationAction::new()
+    }
+
+    /// Update the statistics of table
+    pub fn update_statistics(&self) -> UpdateStatisticsAction {
+        UpdateStatisticsAction::new()
     }
 
     /// Commit transaction.

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -158,11 +158,8 @@ impl Transaction {
     }
 
     /// Creates replace sort order action.
-    pub fn replace_sort_order(self) -> ReplaceSortOrderAction {
-        ReplaceSortOrderAction {
-            tx: self,
-            sort_fields: vec![],
-        }
+    pub fn replace_sort_order(&self) -> ReplaceSortOrderAction {
+        ReplaceSortOrderAction::new()
     }
 
     /// Set the location of table

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -16,6 +16,37 @@
 // under the License.
 
 //! This module contains transaction api.
+//!
+//! The transaction API enables changes to be made to an existing table.
+//!
+//! Note that this may also have side effects, such as producing new manifest
+//! files.
+//!
+//! Below is a basic example using the "fast-append" action:
+//!
+//! ```ignore
+//! use iceberg::transaction::{ApplyTransactionAction, Transaction};
+//! use iceberg::Catalog;
+//!
+//! // Create a transaction.
+//! let tx = Transaction::new(my_table);
+//!
+//! // Create a `FastAppendAction` which will not rewrite or append
+//! // to existing metadata. This will create a new manifest.
+//! let action = tx.fast_append().add_data_files(my_data_files);
+//!
+//! // Apply the fast-append action to the given transaction, returning
+//! // the newly updated `Transaction`.
+//! let tx = action.apply(tx).unwrap();
+//!
+//!
+//! // End the transaction by committing to an `iceberg::Catalog`
+//! // implementation. This will cause a table update to occur.
+//! let table = tx
+//!     .commit(&some_catalog_impl)
+//!     .await
+//!     .unwrap();
+//! ```
 
 /// The `ApplyTransactionAction` trait provides an `apply` method
 /// that allows users to apply a transaction action to a `Transaction`.

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::ops::RangeFrom;
 
@@ -29,7 +29,8 @@ use crate::spec::{
     PROPERTY_WRITE_PARTITION_SUMMARY_LIMIT_DEFAULT, Snapshot, SnapshotReference, SnapshotRetention,
     SnapshotSummaryCollector, Struct, StructType, Summary, update_snapshot_summaries,
 };
-use crate::transaction::Transaction;
+use crate::table::Table;
+use crate::transaction::ActionCommit;
 use crate::{Error, ErrorKind, TableRequirement, TableUpdate};
 
 const META_ROOT_PATH: &str = "metadata";
@@ -39,11 +40,11 @@ pub(crate) trait SnapshotProduceOperation: Send + Sync {
     #[allow(unused)]
     fn delete_entries(
         &self,
-        snapshot_produce: &SnapshotProduceAction,
+        snapshot_produce: &SnapshotProducer,
     ) -> impl Future<Output = Result<Vec<ManifestEntry>>> + Send;
     fn existing_manifest(
         &self,
-        snapshot_produce: &SnapshotProduceAction,
+        table: &Table,
     ) -> impl Future<Output = Result<Vec<ManifestFile>>> + Send;
 }
 
@@ -59,36 +60,111 @@ pub(crate) trait ManifestProcess: Send + Sync {
     fn process_manifests(&self, manifests: Vec<ManifestFile>) -> Vec<ManifestFile>;
 }
 
-pub(crate) struct SnapshotProduceAction {
-    pub tx: Transaction,
+pub(crate) struct SnapshotProducer {
     snapshot_id: i64,
-    key_metadata: Vec<u8>,
     commit_uuid: Uuid,
+    key_metadata: Option<Vec<u8>>,
     snapshot_properties: HashMap<String, String>,
-    pub added_data_files: Vec<DataFile>,
+    added_data_files: Vec<DataFile>,
     // A counter used to generate unique manifest file names.
     // It starts from 0 and increments for each new manifest file.
     // Note: This counter is limited to the range of (0..u64::MAX).
     manifest_counter: RangeFrom<u64>,
 }
 
-impl SnapshotProduceAction {
+impl SnapshotProducer {
     pub(crate) fn new(
-        tx: Transaction,
         snapshot_id: i64,
-        key_metadata: Vec<u8>,
         commit_uuid: Uuid,
+        key_metadata: Option<Vec<u8>>,
         snapshot_properties: HashMap<String, String>,
-    ) -> Result<Self> {
-        Ok(Self {
-            tx,
+        added_data_files: Vec<DataFile>,
+    ) -> Self {
+        Self {
             snapshot_id,
             commit_uuid,
-            snapshot_properties,
-            added_data_files: vec![],
-            manifest_counter: (0..),
             key_metadata,
-        })
+            snapshot_properties,
+            added_data_files,
+            manifest_counter: (0..),
+        }
+    }
+
+    pub(crate) fn validate_added_data_files(
+        table: &Table,
+        added_data_files: &[DataFile],
+    ) -> Result<()> {
+        for data_file in added_data_files {
+            if data_file.content_type() != crate::spec::DataContentType::Data {
+                return Err(Error::new(
+                    ErrorKind::DataInvalid,
+                    "Only data content type is allowed for fast append",
+                ));
+            }
+            // Check if the data file partition spec id matches the table default partition spec id.
+            if table.metadata().default_partition_spec_id() != data_file.partition_spec_id {
+                return Err(Error::new(
+                    ErrorKind::DataInvalid,
+                    "Data file partition spec id does not match table default partition spec id",
+                ));
+            }
+            Self::validate_partition_value(
+                data_file.partition(),
+                table.metadata().default_partition_type(),
+            )?;
+        }
+
+        Ok(())
+    }
+
+    pub(crate) async fn validate_duplicate_files(
+        table: &Table,
+        added_data_files: &[DataFile],
+    ) -> Result<()> {
+        let new_files: HashSet<&str> = added_data_files
+            .iter()
+            .map(|df| df.file_path.as_str())
+            .collect();
+
+        let mut referenced_files = Vec::new();
+        if let Some(current_snapshot) = table.metadata().current_snapshot() {
+            let manifest_list = current_snapshot
+                .load_manifest_list(table.file_io(), &table.metadata_ref())
+                .await?;
+            for manifest_list_entry in manifest_list.entries() {
+                let manifest = manifest_list_entry.load_manifest(table.file_io()).await?;
+                for entry in manifest.entries() {
+                    let file_path = entry.file_path();
+                    if new_files.contains(file_path) && entry.is_alive() {
+                        referenced_files.push(file_path.to_string());
+                    }
+                }
+            }
+        }
+
+        if !referenced_files.is_empty() {
+            return Err(Error::new(
+                ErrorKind::DataInvalid,
+                format!(
+                    "Cannot add files that are already referenced by table, files: {}",
+                    referenced_files.join(", ")
+                ),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn new_manifest_output(&mut self, table: &Table) -> Result<OutputFile> {
+        let new_manifest_path = format!(
+            "{}/{}/{}-m{}.{}",
+            table.metadata().location(),
+            META_ROOT_PATH,
+            self.commit_uuid,
+            self.manifest_counter.next().unwrap(),
+            DataFileFormat::Avro
+        );
+        table.file_io().new_output(new_manifest_path)
     }
 
     // Check if the partition value is compatible with the partition type.
@@ -122,63 +198,8 @@ impl SnapshotProduceAction {
         Ok(())
     }
 
-    /// Set snapshot summary properties.
-    pub fn set_snapshot_properties(
-        &mut self,
-        snapshot_properties: HashMap<String, String>,
-    ) -> Result<&mut Self> {
-        self.snapshot_properties = snapshot_properties;
-        Ok(self)
-    }
-
-    /// Add data files to the snapshot.
-    pub fn add_data_files(
-        &mut self,
-        data_files: impl IntoIterator<Item = DataFile>,
-    ) -> Result<&mut Self> {
-        let data_files: Vec<DataFile> = data_files.into_iter().collect();
-        for data_file in &data_files {
-            if data_file.content_type() != crate::spec::DataContentType::Data {
-                return Err(Error::new(
-                    ErrorKind::DataInvalid,
-                    "Only data content type is allowed for fast append",
-                ));
-            }
-            // Check if the data file partition spec id matches the table default partition spec id.
-            if self.tx.current_table.metadata().default_partition_spec_id()
-                != data_file.partition_spec_id
-            {
-                return Err(Error::new(
-                    ErrorKind::DataInvalid,
-                    "Data file partition spec id does not match table default partition spec id",
-                ));
-            }
-            Self::validate_partition_value(
-                data_file.partition(),
-                self.tx.current_table.metadata().default_partition_type(),
-            )?;
-        }
-        self.added_data_files.extend(data_files);
-        Ok(self)
-    }
-
-    fn new_manifest_output(&mut self) -> Result<OutputFile> {
-        let new_manifest_path = format!(
-            "{}/{}/{}-m{}.{}",
-            self.tx.current_table.metadata().location(),
-            META_ROOT_PATH,
-            self.commit_uuid,
-            self.manifest_counter.next().unwrap(),
-            DataFileFormat::Avro
-        );
-        self.tx
-            .current_table
-            .file_io()
-            .new_output(new_manifest_path)
-    }
-
     // Write manifest file for added data files and return the ManifestFile for ManifestList.
-    async fn write_added_manifest(&mut self) -> Result<ManifestFile> {
+    async fn write_added_manifest(&mut self, table: &Table) -> Result<ManifestFile> {
         let added_data_files = std::mem::take(&mut self.added_data_files);
         if added_data_files.is_empty() {
             return Err(Error::new(
@@ -188,7 +209,7 @@ impl SnapshotProduceAction {
         }
 
         let snapshot_id = self.snapshot_id;
-        let format_version = self.tx.current_table.metadata().format_version();
+        let format_version = table.metadata().format_version();
         let manifest_entries = added_data_files.into_iter().map(|data_file| {
             let builder = ManifestEntry::builder()
                 .status(crate::spec::ManifestStatus::Added)
@@ -203,18 +224,13 @@ impl SnapshotProduceAction {
         });
         let mut writer = {
             let builder = ManifestWriterBuilder::new(
-                self.new_manifest_output()?,
+                self.new_manifest_output(table)?,
                 Some(self.snapshot_id),
                 self.key_metadata.clone(),
-                self.tx.current_table.metadata().current_schema().clone(),
-                self.tx
-                    .current_table
-                    .metadata()
-                    .default_partition_spec()
-                    .as_ref()
-                    .clone(),
+                table.metadata().current_schema().clone(),
+                table.metadata().default_partition_spec().as_ref().clone(),
             );
-            if self.tx.current_table.metadata().format_version() == FormatVersion::V1 {
+            if table.metadata().format_version() == FormatVersion::V1 {
                 builder.build_v1()
             } else {
                 builder.build_v2_data()
@@ -228,11 +244,12 @@ impl SnapshotProduceAction {
 
     async fn manifest_file<OP: SnapshotProduceOperation, MP: ManifestProcess>(
         &mut self,
+        table: &Table,
         snapshot_produce_operation: &OP,
         manifest_process: &MP,
     ) -> Result<Vec<ManifestFile>> {
-        let added_manifest = self.write_added_manifest().await?;
-        let existing_manifests = snapshot_produce_operation.existing_manifest(self).await?;
+        let added_manifest = self.write_added_manifest(table).await?;
+        let existing_manifests = snapshot_produce_operation.existing_manifest(table).await?;
         // # TODO
         // Support process delete entries.
 
@@ -245,10 +262,11 @@ impl SnapshotProduceAction {
     // Returns a `Summary` of the current snapshot
     fn summary<OP: SnapshotProduceOperation>(
         &self,
+        table: &Table,
         snapshot_produce_operation: &OP,
     ) -> Result<Summary> {
         let mut summary_collector = SnapshotSummaryCollector::default();
-        let table_metadata = self.tx.current_table.metadata_ref();
+        let table_metadata = table.metadata_ref();
 
         let partition_summary_limit = if let Some(limit) = table_metadata
             .properties()
@@ -293,10 +311,10 @@ impl SnapshotProduceAction {
         )
     }
 
-    fn generate_manifest_list_file_path(&self, attempt: i64) -> String {
+    fn generate_manifest_list_file_path(&self, table: &Table, attempt: i64) -> String {
         format!(
             "{}/{}/snap-{}-{}-{}.{}",
-            self.tx.current_table.metadata().location(),
+            table.metadata().location(),
             META_ROOT_PATH,
             self.snapshot_id,
             attempt,
@@ -305,43 +323,37 @@ impl SnapshotProduceAction {
         )
     }
 
-    /// Finished building the action and apply it to the transaction.
-    pub async fn apply<OP: SnapshotProduceOperation, MP: ManifestProcess>(
+    /// Finished building the action and return the [`ActionCommit`] to the transaction.
+    pub(crate) async fn commit<OP: SnapshotProduceOperation, MP: ManifestProcess>(
         mut self,
+        table: &Table,
         snapshot_produce_operation: OP,
         process: MP,
-    ) -> Result<Transaction> {
+    ) -> Result<ActionCommit> {
         let new_manifests = self
-            .manifest_file(&snapshot_produce_operation, &process)
+            .manifest_file(table, &snapshot_produce_operation, &process)
             .await?;
-        let next_seq_num = self.tx.current_table.metadata().next_sequence_number();
+        let next_seq_num = table.metadata().next_sequence_number();
 
         let summary = self
-            .summary(&snapshot_produce_operation)
+            .summary(table, &snapshot_produce_operation)
             .map_err(|err| {
                 Error::new(ErrorKind::Unexpected, "Failed to create snapshot summary.")
                     .with_source(err)
-            })
-            .unwrap();
+            })?;
 
-        let manifest_list_path = self.generate_manifest_list_file_path(0);
+        let manifest_list_path = self.generate_manifest_list_file_path(table, 0);
 
-        let mut manifest_list_writer = match self.tx.current_table.metadata().format_version() {
+        let mut manifest_list_writer = match table.metadata().format_version() {
             FormatVersion::V1 => ManifestListWriter::v1(
-                self.tx
-                    .current_table
-                    .file_io()
-                    .new_output(manifest_list_path.clone())?,
+                table.file_io().new_output(manifest_list_path.clone())?,
                 self.snapshot_id,
-                self.tx.current_table.metadata().current_snapshot_id(),
+                table.metadata().current_snapshot_id(),
             ),
             FormatVersion::V2 => ManifestListWriter::v2(
-                self.tx
-                    .current_table
-                    .file_io()
-                    .new_output(manifest_list_path.clone())?,
+                table.file_io().new_output(manifest_list_path.clone())?,
                 self.snapshot_id,
-                self.tx.current_table.metadata().current_snapshot_id(),
+                table.metadata().current_snapshot_id(),
                 next_seq_num,
             ),
         };
@@ -352,37 +364,36 @@ impl SnapshotProduceAction {
         let new_snapshot = Snapshot::builder()
             .with_manifest_list(manifest_list_path)
             .with_snapshot_id(self.snapshot_id)
-            .with_parent_snapshot_id(self.tx.current_table.metadata().current_snapshot_id())
+            .with_parent_snapshot_id(table.metadata().current_snapshot_id())
             .with_sequence_number(next_seq_num)
             .with_summary(summary)
-            .with_schema_id(self.tx.current_table.metadata().current_schema_id())
+            .with_schema_id(table.metadata().current_schema_id())
             .with_timestamp_ms(commit_ts)
             .build();
 
-        self.tx.apply(
-            vec![
-                TableUpdate::AddSnapshot {
-                    snapshot: new_snapshot,
-                },
-                TableUpdate::SetSnapshotRef {
-                    ref_name: MAIN_BRANCH.to_string(),
-                    reference: SnapshotReference::new(
-                        self.snapshot_id,
-                        SnapshotRetention::branch(None, None, None),
-                    ),
-                },
-            ],
-            vec![
-                TableRequirement::UuidMatch {
-                    uuid: self.tx.current_table.metadata().uuid(),
-                },
-                TableRequirement::RefSnapshotIdMatch {
-                    r#ref: MAIN_BRANCH.to_string(),
-                    snapshot_id: self.tx.current_table.metadata().current_snapshot_id(),
-                },
-            ],
-        )?;
+        let updates = vec![
+            TableUpdate::AddSnapshot {
+                snapshot: new_snapshot,
+            },
+            TableUpdate::SetSnapshotRef {
+                ref_name: MAIN_BRANCH.to_string(),
+                reference: SnapshotReference::new(
+                    self.snapshot_id,
+                    SnapshotRetention::branch(None, None, None),
+                ),
+            },
+        ];
 
-        Ok(self.tx)
+        let requirements = vec![
+            TableRequirement::UuidMatch {
+                uuid: table.metadata().uuid(),
+            },
+            TableRequirement::RefSnapshotIdMatch {
+                r#ref: MAIN_BRANCH.to_string(),
+                snapshot_id: table.metadata().current_snapshot_id(),
+            },
+        ];
+
+        Ok(ActionCommit::new(updates, requirements))
     }
 }

--- a/crates/iceberg/src/transaction/sort_order.rs
+++ b/crates/iceberg/src/transaction/sort_order.rs
@@ -15,63 +15,64 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
 use crate::error::Result;
-use crate::spec::{NullOrder, SortDirection, SortField, SortOrder, Transform};
-use crate::transaction::Transaction;
+use crate::spec::{NullOrder, SchemaRef, SortDirection, SortField, SortOrder, Transform};
+use crate::table::Table;
+use crate::transaction::{ActionCommit, TransactionAction};
 use crate::{Error, ErrorKind, TableRequirement, TableUpdate};
+
+/// Represents a sort field whose construction and validation are deferred until commit time.
+/// This avoids the need to pass a `Table` reference into methods like `asc` or `desc` when
+/// adding sort orders.
+#[derive(Debug, PartialEq, Eq, Clone)]
+struct PendingSortField {
+    name: String,
+    direction: SortDirection,
+    null_order: NullOrder,
+}
+
+impl PendingSortField {
+    fn to_sort_field(&self, schema: &SchemaRef) -> Result<SortField> {
+        let field_id = schema.field_id_by_name(self.name.as_str()).ok_or_else(|| {
+            Error::new(
+                ErrorKind::DataInvalid,
+                format!("Cannot find field {} in table schema", self.name),
+            )
+        })?;
+
+        Ok(SortField::builder()
+            .source_id(field_id)
+            .transform(Transform::Identity)
+            .direction(self.direction)
+            .null_order(self.null_order)
+            .build())
+    }
+}
 
 /// Transaction action for replacing sort order.
 pub struct ReplaceSortOrderAction {
-    pub tx: Transaction,
-    pub sort_fields: Vec<SortField>,
+    pending_sort_fields: Vec<PendingSortField>,
 }
 
 impl ReplaceSortOrderAction {
+    pub fn new() -> Self {
+        ReplaceSortOrderAction {
+            pending_sort_fields: vec![],
+        }
+    }
+
     /// Adds a field for sorting in ascending order.
-    pub fn asc(self, name: &str, null_order: NullOrder) -> Result<Self> {
+    pub fn asc(self, name: &str, null_order: NullOrder) -> Self {
         self.add_sort_field(name, SortDirection::Ascending, null_order)
     }
 
     /// Adds a field for sorting in descending order.
-    pub fn desc(self, name: &str, null_order: NullOrder) -> Result<Self> {
+    pub fn desc(self, name: &str, null_order: NullOrder) -> Self {
         self.add_sort_field(name, SortDirection::Descending, null_order)
-    }
-
-    /// Finished building the action and apply it to the transaction.
-    pub fn apply(mut self) -> Result<Transaction> {
-        let unbound_sort_order = SortOrder::builder()
-            .with_fields(self.sort_fields)
-            .build_unbound()?;
-
-        let updates = vec![
-            TableUpdate::AddSortOrder {
-                sort_order: unbound_sort_order,
-            },
-            TableUpdate::SetDefaultSortOrder { sort_order_id: -1 },
-        ];
-
-        let requirements = vec![
-            TableRequirement::CurrentSchemaIdMatch {
-                current_schema_id: self
-                    .tx
-                    .current_table
-                    .metadata()
-                    .current_schema()
-                    .schema_id(),
-            },
-            TableRequirement::DefaultSortOrderIdMatch {
-                default_sort_order_id: self
-                    .tx
-                    .current_table
-                    .metadata()
-                    .default_sort_order()
-                    .order_id,
-            },
-        ];
-
-        self.tx.apply(updates, requirements)?;
-
-        Ok(self.tx)
     }
 
     fn add_sort_field(
@@ -79,64 +80,93 @@ impl ReplaceSortOrderAction {
         name: &str,
         sort_direction: SortDirection,
         null_order: NullOrder,
-    ) -> Result<Self> {
-        let field_id = self
-            .tx
-            .current_table
-            .metadata()
-            .current_schema()
-            .field_id_by_name(name)
-            .ok_or_else(|| {
-                Error::new(
-                    ErrorKind::DataInvalid,
-                    format!("Cannot find field {} in table schema", name),
-                )
-            })?;
+    ) -> Self {
+        self.pending_sort_fields.push(PendingSortField {
+            name: name.to_string(),
+            direction: sort_direction,
+            null_order,
+        });
 
-        let sort_field = SortField::builder()
-            .source_id(field_id)
-            .transform(Transform::Identity)
-            .direction(sort_direction)
-            .null_order(null_order)
-            .build();
+        self
+    }
+}
 
-        self.sort_fields.push(sort_field);
-        Ok(self)
+impl Default for ReplaceSortOrderAction {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl TransactionAction for ReplaceSortOrderAction {
+    async fn commit(self: Arc<Self>, table: &Table) -> Result<ActionCommit> {
+        let current_schema = table.metadata().current_schema();
+        let sort_fields: Result<Vec<SortField>> = self
+            .pending_sort_fields
+            .iter()
+            .map(|p| p.to_sort_field(current_schema))
+            .collect();
+
+        let bound_sort_order = SortOrder::builder()
+            .with_fields(sort_fields?)
+            .build(current_schema)?;
+
+        let updates = vec![
+            TableUpdate::AddSortOrder {
+                sort_order: bound_sort_order,
+            },
+            TableUpdate::SetDefaultSortOrder { sort_order_id: -1 },
+        ];
+
+        let requirements = vec![
+            TableRequirement::CurrentSchemaIdMatch {
+                current_schema_id: current_schema.schema_id(),
+            },
+            TableRequirement::DefaultSortOrderIdMatch {
+                default_sort_order_id: table.metadata().default_sort_order().order_id,
+            },
+        ];
+
+        Ok(ActionCommit::new(updates, requirements))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::transaction::Transaction;
+    use as_any::Downcast;
+
+    use crate::spec::{NullOrder, SortDirection};
+    use crate::transaction::sort_order::{PendingSortField, ReplaceSortOrderAction};
     use crate::transaction::tests::make_v2_table;
-    use crate::{TableRequirement, TableUpdate};
+    use crate::transaction::{ApplyTransactionAction, Transaction};
 
     #[test]
     fn test_replace_sort_order() {
         let table = make_v2_table();
         let tx = Transaction::new(&table);
-        let tx = tx.replace_sort_order().apply().unwrap();
+        let replace_sort_order = tx.replace_sort_order();
 
-        assert_eq!(
-            vec![
-                TableUpdate::AddSortOrder {
-                    sort_order: Default::default()
-                },
-                TableUpdate::SetDefaultSortOrder { sort_order_id: -1 }
-            ],
-            tx.updates
-        );
+        let tx = replace_sort_order
+            .asc("x", NullOrder::First)
+            .desc("y", NullOrder::Last)
+            .apply(tx)
+            .unwrap();
 
-        assert_eq!(
-            vec![
-                TableRequirement::CurrentSchemaIdMatch {
-                    current_schema_id: 1
-                },
-                TableRequirement::DefaultSortOrderIdMatch {
-                    default_sort_order_id: 3
-                }
-            ],
-            tx.requirements
-        );
+        let replace_sort_order = (*tx.actions[0])
+            .downcast_ref::<ReplaceSortOrderAction>()
+            .unwrap();
+
+        assert_eq!(replace_sort_order.pending_sort_fields, vec![
+            PendingSortField {
+                name: String::from("x"),
+                direction: SortDirection::Ascending,
+                null_order: NullOrder::First,
+            },
+            PendingSortField {
+                name: String::from("y"),
+                direction: SortDirection::Descending,
+                null_order: NullOrder::Last,
+            }
+        ]);
     }
 }

--- a/crates/iceberg/src/transaction/update_location.rs
+++ b/crates/iceberg/src/transaction/update_location.rs
@@ -1,0 +1,109 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::table::Table;
+use crate::transaction::action::{ActionCommit, TransactionAction};
+use crate::{Error, ErrorKind, Result, TableUpdate};
+
+/// A transaction action that sets or updates the location of a table.
+///
+/// This action is used to explicitly set a new metadata location during a transaction,
+/// typically as part of advanced commit or recovery flows. The location is optional until
+/// explicitly set via [`set_location`].
+pub struct UpdateLocationAction {
+    location: Option<String>,
+}
+
+impl UpdateLocationAction {
+    /// Creates a new [`UpdateLocationAction`] with no location set.
+    pub fn new() -> Self {
+        UpdateLocationAction { location: None }
+    }
+
+    /// Sets the target location for this action and returns the updated instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `location` - A string representing the table's location.
+    ///
+    /// # Returns
+    ///
+    /// The [`UpdateLocationAction`] with the new location set.
+    pub fn set_location(mut self, location: String) -> Self {
+        self.location = Some(location);
+        self
+    }
+}
+
+impl Default for UpdateLocationAction {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl TransactionAction for UpdateLocationAction {
+    async fn commit(self: Arc<Self>, _table: &Table) -> Result<ActionCommit> {
+        let updates: Vec<TableUpdate>;
+        if let Some(location) = self.location.clone() {
+            updates = vec![TableUpdate::SetLocation { location }];
+        } else {
+            return Err(Error::new(
+                ErrorKind::DataInvalid,
+                "Location is not set for UpdateLocationAction!",
+            ));
+        }
+
+        Ok(ActionCommit::new(updates, vec![]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use as_any::Downcast;
+
+    use crate::transaction::Transaction;
+    use crate::transaction::action::ApplyTransactionAction;
+    use crate::transaction::tests::make_v2_table;
+    use crate::transaction::update_location::UpdateLocationAction;
+
+    #[test]
+    fn test_set_location() {
+        let table = make_v2_table();
+        let tx = Transaction::new(&table);
+        let tx = tx
+            .update_location()
+            .set_location(String::from("s3://bucket/prefix/new_table"))
+            .apply(tx)
+            .unwrap();
+
+        assert_eq!(tx.actions.len(), 1);
+
+        let action = (*tx.actions[0])
+            .downcast_ref::<UpdateLocationAction>()
+            .unwrap();
+
+        assert_eq!(
+            action.location,
+            Some(String::from("s3://bucket/prefix/new_table"))
+        )
+    }
+}

--- a/crates/iceberg/src/transaction/update_properties.rs
+++ b/crates/iceberg/src/transaction/update_properties.rs
@@ -1,0 +1,144 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::table::Table;
+use crate::transaction::action::{ActionCommit, TransactionAction};
+use crate::{Error, ErrorKind, Result, TableUpdate};
+
+/// A transactional action that updates or removes table properties
+///
+/// This action is used to modify key-value pairs in a table's metadata
+/// properties during a transaction. It supports setting new values for existing keys
+/// or adding new keys, as well as removing existing keys. Each key can only be updated
+/// or removed in a single action, not both.
+pub struct UpdatePropertiesAction {
+    updates: HashMap<String, String>,
+    removals: HashSet<String>,
+}
+
+impl UpdatePropertiesAction {
+    /// Creates a new [`UpdatePropertiesAction`] with no updates or removals.
+    pub fn new() -> Self {
+        UpdatePropertiesAction {
+            updates: HashMap::default(),
+            removals: HashSet::default(),
+        }
+    }
+
+    /// Adds a key-value pair to the update set of this action.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The property key to update.
+    /// * `value` - The new value to associate with the key.
+    ///
+    /// # Returns
+    ///
+    /// The updated [`UpdatePropertiesAction`] with the key-value pair added to the update set.
+    pub fn set(mut self, key: String, value: String) -> Self {
+        self.updates.insert(key, value);
+        self
+    }
+
+    /// Adds a key to the removal set of this action.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The property key to remove.
+    ///
+    /// # Returns
+    ///
+    /// The updated [`UpdatePropertiesAction`] with the key added to the removal set.
+    pub fn remove(mut self, key: String) -> Self {
+        self.removals.insert(key);
+        self
+    }
+}
+
+impl Default for UpdatePropertiesAction {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl TransactionAction for UpdatePropertiesAction {
+    async fn commit(self: Arc<Self>, _table: &Table) -> Result<ActionCommit> {
+        if let Some(overlapping_key) = self.removals.iter().find(|k| self.updates.contains_key(*k))
+        {
+            return Err(Error::new(
+                ErrorKind::PreconditionFailed,
+                format!(
+                    "Key {} is present in both removal set and update set",
+                    overlapping_key
+                ),
+            ));
+        }
+
+        let updates: Vec<TableUpdate> = vec![
+            TableUpdate::SetProperties {
+                updates: self.updates.clone(),
+            },
+            TableUpdate::RemoveProperties {
+                removals: self.removals.clone().into_iter().collect::<Vec<String>>(),
+            },
+        ];
+
+        Ok(ActionCommit::new(updates, vec![]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+
+    use as_any::Downcast;
+
+    use crate::transaction::Transaction;
+    use crate::transaction::action::ApplyTransactionAction;
+    use crate::transaction::tests::make_v2_table;
+    use crate::transaction::update_properties::UpdatePropertiesAction;
+
+    #[test]
+    fn test_update_table_property() {
+        let table = make_v2_table();
+        let tx = Transaction::new(&table);
+        let tx = tx
+            .update_table_properties()
+            .set("a".to_string(), "b".to_string())
+            .remove("b".to_string())
+            .apply(tx)
+            .unwrap();
+
+        assert_eq!(tx.actions.len(), 1);
+
+        let action = (*tx.actions[0])
+            .downcast_ref::<UpdatePropertiesAction>()
+            .unwrap();
+        assert_eq!(
+            action.updates,
+            HashMap::from([("a".to_string(), "b".to_string())])
+        );
+
+        assert_eq!(action.removals, HashSet::from(["b".to_string()]));
+    }
+}

--- a/crates/iceberg/src/transaction/update_statistics.rs
+++ b/crates/iceberg/src/transaction/update_statistics.rs
@@ -1,0 +1,174 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::spec::StatisticsFile;
+use crate::table::Table;
+use crate::transaction::{ActionCommit, TransactionAction};
+use crate::{Result, TableUpdate};
+
+/// A transactional action for updating statistics files in a table
+pub struct UpdateStatisticsAction {
+    statistics_to_set: HashMap<i64, Option<StatisticsFile>>,
+}
+
+impl UpdateStatisticsAction {
+    pub fn new() -> Self {
+        Self {
+            statistics_to_set: HashMap::default(),
+        }
+    }
+
+    /// Set the table's statistics file for given snapshot, replacing the previous statistics file for
+    /// the snapshot if any exists. The snapshot id of the statistics file will be used.
+    ///
+    /// # Arguments
+    ///
+    /// * `statistics_file` - The [`StatisticsFile`] to associate with its corresponding snapshot ID.
+    ///
+    /// # Returns
+    ///
+    /// An updated [`UpdateStatisticsAction`] with the new statistics file applied.
+    pub fn set_statistics(mut self, statistics_file: StatisticsFile) -> Self {
+        self.statistics_to_set
+            .insert(statistics_file.snapshot_id, Some(statistics_file));
+        self
+    }
+
+    /// Remove the table's statistics file for given snapshot.
+    ///
+    /// # Arguments
+    ///
+    /// * `snapshot_id` - The ID of the snapshot whose statistics file should be removed.
+    ///
+    /// # Returns
+    ///
+    /// An updated [`UpdateStatisticsAction`] with the removal operation recorded.
+    pub fn remove_statistics(mut self, snapshot_id: i64) -> Self {
+        self.statistics_to_set.insert(snapshot_id, None);
+        self
+    }
+}
+
+impl Default for UpdateStatisticsAction {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl TransactionAction for UpdateStatisticsAction {
+    async fn commit(self: Arc<Self>, _table: &Table) -> Result<ActionCommit> {
+        let mut updates: Vec<TableUpdate> = vec![];
+
+        self.statistics_to_set
+            .iter()
+            .for_each(|(snapshot_id, statistic_file)| {
+                if let Some(statistics) = statistic_file {
+                    updates.push(TableUpdate::SetStatistics {
+                        statistics: statistics.clone(),
+                    })
+                } else {
+                    updates.push(TableUpdate::RemoveStatistics {
+                        snapshot_id: *snapshot_id,
+                    })
+                }
+            });
+
+        Ok(ActionCommit::new(updates, vec![]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use as_any::Downcast;
+
+    use crate::spec::{BlobMetadata, StatisticsFile};
+    use crate::transaction::tests::make_v2_table;
+    use crate::transaction::update_statistics::UpdateStatisticsAction;
+    use crate::transaction::{ApplyTransactionAction, Transaction};
+
+    #[test]
+    fn test_update_statistics() {
+        let table = make_v2_table();
+        let tx = Transaction::new(&table);
+
+        let statistics_file_1 = StatisticsFile {
+            snapshot_id: 3055729675574597004i64,
+            statistics_path: "s3://a/b/stats.puffin".to_string(),
+            file_size_in_bytes: 413,
+            file_footer_size_in_bytes: 42,
+            key_metadata: None,
+            blob_metadata: vec![BlobMetadata {
+                r#type: "ndv".to_string(),
+                snapshot_id: 3055729675574597004i64,
+                sequence_number: 1,
+                fields: vec![1],
+                properties: HashMap::new(),
+            }],
+        };
+
+        let statistics_file_2 = StatisticsFile {
+            snapshot_id: 3366729675595277004i64,
+            statistics_path: "s3://a/b/stats.puffin".to_string(),
+            file_size_in_bytes: 413,
+            file_footer_size_in_bytes: 42,
+            key_metadata: None,
+            blob_metadata: vec![BlobMetadata {
+                r#type: "ndv".to_string(),
+                snapshot_id: 3366729675595277004i64,
+                sequence_number: 1,
+                fields: vec![1],
+                properties: HashMap::new(),
+            }],
+        };
+
+        // set stats1
+        let tx = tx
+            .update_statistics()
+            .set_statistics(statistics_file_1.clone())
+            .set_statistics(statistics_file_2.clone())
+            .remove_statistics(3055729675574597004i64) // remove stats1
+            .apply(tx)
+            .unwrap();
+
+        let action = (*tx.actions[0])
+            .downcast_ref::<UpdateStatisticsAction>()
+            .unwrap();
+        assert!(
+            action
+                .statistics_to_set
+                .get(&statistics_file_1.snapshot_id)
+                .unwrap()
+                .is_none()
+        ); // stats1 should have been removed
+        assert_eq!(
+            action
+                .statistics_to_set
+                .get(&statistics_file_2.snapshot_id)
+                .unwrap()
+                .clone(),
+            Some(statistics_file_2)
+        );
+    }
+}

--- a/crates/iceberg/src/transaction/upgrade_format_version.rs
+++ b/crates/iceberg/src/transaction/upgrade_format_version.rs
@@ -1,0 +1,110 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::TableUpdate::UpgradeFormatVersion;
+use crate::spec::FormatVersion;
+use crate::table::Table;
+use crate::transaction::action::{ActionCommit, TransactionAction};
+use crate::{Error, ErrorKind, Result};
+
+/// A transaction action to upgrade a table's format version.
+///
+/// This action is used within a transaction to indicate that the
+/// table's format version should be upgraded to a specified version.
+/// The location remains optional until explicitly set via [`set_format_version`].
+pub struct UpgradeFormatVersionAction {
+    format_version: Option<FormatVersion>,
+}
+
+impl UpgradeFormatVersionAction {
+    /// Creates a new `UpgradeFormatVersionAction` with no version set.
+    pub fn new() -> Self {
+        UpgradeFormatVersionAction {
+            format_version: None,
+        }
+    }
+
+    /// Sets the target format version for the upgrade.
+    ///
+    /// # Arguments
+    ///
+    /// * `format_version` - The version to upgrade the table format to.
+    ///
+    /// # Returns
+    ///
+    /// Returns the updated `UpgradeFormatVersionAction` with the format version set.
+    pub fn set_format_version(mut self, format_version: FormatVersion) -> Self {
+        self.format_version = Some(format_version);
+        self
+    }
+}
+
+impl Default for UpgradeFormatVersionAction {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl TransactionAction for UpgradeFormatVersionAction {
+    async fn commit(self: Arc<Self>, _table: &Table) -> Result<ActionCommit> {
+        let format_version = self.format_version.ok_or_else(|| {
+            Error::new(
+                ErrorKind::DataInvalid,
+                "FormatVersion is not set for UpgradeFormatVersionAction!",
+            )
+        })?;
+
+        Ok(ActionCommit::new(
+            vec![UpgradeFormatVersion { format_version }],
+            vec![],
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use as_any::Downcast;
+
+    use crate::spec::FormatVersion;
+    use crate::transaction::Transaction;
+    use crate::transaction::action::ApplyTransactionAction;
+    use crate::transaction::upgrade_format_version::UpgradeFormatVersionAction;
+
+    #[test]
+    fn test_upgrade_format_version() {
+        let table = crate::transaction::tests::make_v1_table();
+        let tx = Transaction::new(&table);
+        let tx = tx
+            .upgrade_table_version()
+            .set_format_version(FormatVersion::V2)
+            .apply(tx)
+            .unwrap();
+
+        assert_eq!(tx.actions.len(), 1);
+
+        let action = (*tx.actions[0])
+            .downcast_ref::<UpgradeFormatVersionAction>()
+            .unwrap();
+
+        assert_eq!(action.format_version, Some(FormatVersion::V2));
+    }
+}

--- a/crates/integration_tests/tests/shared_tests/append_data_file_test.rs
+++ b/crates/integration_tests/tests/shared_tests/append_data_file_test.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 use arrow_array::{ArrayRef, BooleanArray, Int32Array, RecordBatch, StringArray};
 use futures::TryStreamExt;
-use iceberg::transaction::Transaction;
+use iceberg::transaction::{ApplyTransactionAction, Transaction};
 use iceberg::writer::base_writer::data_file_writer::DataFileWriterBuilder;
 use iceberg::writer::file_writer::ParquetWriterBuilder;
 use iceberg::writer::file_writer::location_generator::{
@@ -112,9 +112,8 @@ async fn test_append_data_file() {
 
     // commit result
     let tx = Transaction::new(&table);
-    let mut append_action = tx.fast_append(None, vec![]).unwrap();
-    append_action.add_data_files(data_file.clone()).unwrap();
-    let tx = append_action.apply().await.unwrap();
+    let append_action = tx.fast_append().add_data_files(data_file.clone());
+    let tx = append_action.apply(tx).unwrap();
     let table = tx.commit(&rest_catalog).await.unwrap();
 
     // check result

--- a/crates/integration_tests/tests/shared_tests/append_partition_data_file_test.rs
+++ b/crates/integration_tests/tests/shared_tests/append_partition_data_file_test.rs
@@ -23,7 +23,7 @@ use arrow_array::{ArrayRef, BooleanArray, Int32Array, RecordBatch, StringArray};
 use futures::TryStreamExt;
 use iceberg::spec::{Literal, PrimitiveLiteral, Struct, Transform, UnboundPartitionSpec};
 use iceberg::table::Table;
-use iceberg::transaction::Transaction;
+use iceberg::transaction::{ApplyTransactionAction, Transaction};
 use iceberg::writer::base_writer::data_file_writer::DataFileWriterBuilder;
 use iceberg::writer::file_writer::ParquetWriterBuilder;
 use iceberg::writer::file_writer::location_generator::{
@@ -120,11 +120,8 @@ async fn test_append_partition_data_file() {
 
     // commit result
     let tx = Transaction::new(&table);
-    let mut append_action = tx.fast_append(None, vec![]).unwrap();
-    append_action
-        .add_data_files(data_file_valid.clone())
-        .unwrap();
-    let tx = append_action.apply().await.unwrap();
+    let append_action = tx.fast_append().add_data_files(data_file_valid.clone());
+    let tx = append_action.apply(tx).unwrap();
     let table = tx.commit(&rest_catalog).await.unwrap();
 
     // check result
@@ -144,6 +141,7 @@ async fn test_append_partition_data_file() {
         parquet_writer_builder.clone(),
         batch.clone(),
         table.clone(),
+        &rest_catalog,
     )
     .await;
 
@@ -151,6 +149,7 @@ async fn test_append_partition_data_file() {
         parquet_writer_builder,
         batch,
         table,
+        &rest_catalog,
         first_partition_id_value,
     )
     .await;
@@ -163,6 +162,7 @@ async fn test_schema_incompatible_partition_type(
     >,
     batch: RecordBatch,
     table: Table,
+    catalog: &dyn Catalog,
 ) {
     // test writing different "type" of partition than mentioned in schema
     let mut data_file_writer_invalid = DataFileWriterBuilder::new(
@@ -180,11 +180,10 @@ async fn test_schema_incompatible_partition_type(
     let data_file_invalid = data_file_writer_invalid.close().await.unwrap();
 
     let tx = Transaction::new(&table);
-    let mut append_action = tx.fast_append(None, vec![]).unwrap();
-    if append_action
-        .add_data_files(data_file_invalid.clone())
-        .is_ok()
-    {
+    let append_action = tx.fast_append().add_data_files(data_file_invalid.clone());
+    let tx = append_action.apply(tx).unwrap();
+
+    if tx.commit(catalog).await.is_ok() {
         panic!("diverging partition info should have returned error");
     }
 }
@@ -196,6 +195,7 @@ async fn test_schema_incompatible_partition_fields(
     >,
     batch: RecordBatch,
     table: Table,
+    catalog: &dyn Catalog,
     first_partition_id_value: i32,
 ) {
     // test writing different number of partition fields than mentioned in schema
@@ -220,11 +220,9 @@ async fn test_schema_incompatible_partition_fields(
     let data_file_invalid = data_file_writer_invalid.close().await.unwrap();
 
     let tx = Transaction::new(&table);
-    let mut append_action = tx.fast_append(None, vec![]).unwrap();
-    if append_action
-        .add_data_files(data_file_invalid.clone())
-        .is_ok()
-    {
+    let append_action = tx.fast_append().add_data_files(data_file_invalid.clone());
+    let tx = append_action.apply(tx).unwrap();
+    if tx.commit(catalog).await.is_ok() {
         panic!("passing different number of partition fields should have returned error");
     }
 }

--- a/crates/integration_tests/tests/shared_tests/conflict_commit_test.rs
+++ b/crates/integration_tests/tests/shared_tests/conflict_commit_test.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 use arrow_array::{ArrayRef, BooleanArray, Int32Array, RecordBatch, StringArray};
 use futures::TryStreamExt;
-use iceberg::transaction::Transaction;
+use iceberg::transaction::{ApplyTransactionAction, Transaction};
 use iceberg::writer::base_writer::data_file_writer::DataFileWriterBuilder;
 use iceberg::writer::file_writer::ParquetWriterBuilder;
 use iceberg::writer::file_writer::location_generator::{
@@ -90,14 +90,12 @@ async fn test_append_data_file_conflict() {
 
     // start two transaction and commit one of them
     let tx1 = Transaction::new(&table);
-    let mut append_action = tx1.fast_append(None, vec![]).unwrap();
-    append_action.add_data_files(data_file.clone()).unwrap();
-    let tx1 = append_action.apply().await.unwrap();
+    let append_action = tx1.fast_append().add_data_files(data_file.clone());
+    let tx1 = append_action.apply(tx1).unwrap();
 
     let tx2 = Transaction::new(&table);
-    let mut append_action = tx2.fast_append(None, vec![]).unwrap();
-    append_action.add_data_files(data_file.clone()).unwrap();
-    let tx2 = append_action.apply().await.unwrap();
+    let append_action = tx2.fast_append().add_data_files(data_file.clone());
+    let tx2 = append_action.apply(tx2).unwrap();
     let table = tx2
         .commit(&rest_catalog)
         .await

--- a/crates/integration_tests/tests/shared_tests/scan_all_type.rs
+++ b/crates/integration_tests/tests/shared_tests/scan_all_type.rs
@@ -33,7 +33,7 @@ use iceberg::spec::{
     LIST_FIELD_NAME, ListType, MAP_KEY_FIELD_NAME, MAP_VALUE_FIELD_NAME, MapType, NestedField,
     PrimitiveType, Schema, StructType, Type,
 };
-use iceberg::transaction::Transaction;
+use iceberg::transaction::{ApplyTransactionAction, Transaction};
 use iceberg::writer::base_writer::data_file_writer::DataFileWriterBuilder;
 use iceberg::writer::file_writer::ParquetWriterBuilder;
 use iceberg::writer::file_writer::location_generator::{
@@ -309,9 +309,8 @@ async fn test_scan_all_type() {
 
     // commit result
     let tx = Transaction::new(&table);
-    let mut append_action = tx.fast_append(None, vec![]).unwrap();
-    append_action.add_data_files(data_file.clone()).unwrap();
-    let tx = append_action.apply().await.unwrap();
+    let append_action = tx.fast_append().add_data_files(data_file.clone());
+    let tx = append_action.apply(tx).unwrap();
     let table = tx.commit(&rest_catalog).await.unwrap();
 
     // check result

--- a/crates/integrations/datafusion/src/physical_plan/expr_to_predicate.rs
+++ b/crates/integrations/datafusion/src/physical_plan/expr_to_predicate.rs
@@ -51,7 +51,17 @@ pub fn convert_filters_to_predicate(filters: &[Expr]) -> Option<Predicate> {
 fn convert_filter_to_predicate(expr: &Expr) -> Option<Predicate> {
     match to_iceberg_predicate(expr) {
         TransformedResult::Predicate(predicate) => Some(predicate),
-        TransformedResult::Column(_) | TransformedResult::Literal(_) => {
+        TransformedResult::Column(r) => {
+            match to_iceberg_binary_predicate(
+                TransformedResult::Column(r),
+                TransformedResult::Literal(Datum::bool(true)),
+                PredicateOperator::Eq,
+            ) {
+                TransformedResult::Predicate(p) => Some(p),
+                _ => unreachable!("Not a valid expression: {:?}", expr),
+            }
+        }
+        TransformedResult::Literal(_) => {
             unreachable!("Not a valid expression: {:?}", expr)
         }
         _ => None,
@@ -75,6 +85,11 @@ fn to_iceberg_predicate(expr: &Expr) -> TransformedResult {
             let expr = to_iceberg_predicate(exp);
             match expr {
                 TransformedResult::Predicate(p) => TransformedResult::Predicate(!p),
+                TransformedResult::Column(r) => to_iceberg_binary_predicate(
+                    TransformedResult::Column(r),
+                    TransformedResult::Literal(Datum::bool(false)),
+                    PredicateOperator::Eq,
+                ),
                 _ => TransformedResult::NotTransformed,
             }
         }
@@ -214,6 +229,7 @@ fn scalar_value_to_datum(value: &ScalarValue) -> Option<Datum> {
         ScalarValue::LargeUtf8(Some(v)) => Some(Datum::string(v.clone())),
         ScalarValue::Date32(Some(v)) => Some(Datum::date(*v)),
         ScalarValue::Date64(Some(v)) => Some(Datum::date((*v / MILLIS_PER_DAY) as i32)),
+        ScalarValue::Boolean(Some(v)) => Some(Datum::bool(*v)),
         _ => None,
     }
 }
@@ -223,7 +239,7 @@ mod tests {
     use std::collections::HashMap;
 
     use datafusion::arrow::datatypes::{DataType, Field, Schema, TimeUnit};
-    use datafusion::common::DFSchema;
+    use datafusion::common::{Column, DFSchema};
     use datafusion::logical_expr::utils::split_conjunction;
     use datafusion::prelude::{Expr, SessionContext};
     use iceberg::expr::{Predicate, Reference};
@@ -349,6 +365,41 @@ mod tests {
         let sql = "foo > 1 and length(bar) = 1";
         let predicate = convert_to_iceberg_predicate(sql).unwrap();
         let expected_predicate = Reference::new("foo").greater_than(Datum::long(1));
+        assert_eq!(predicate, expected_predicate);
+    }
+
+    #[test]
+    fn test_predicate_conversion_boolean_column_true() {
+        let sql = "foo = true";
+        let predicate = convert_to_iceberg_predicate(sql).unwrap();
+        let expected_predicate = Reference::new("foo").equal_to(Datum::bool(true));
+        assert_eq!(predicate, expected_predicate);
+    }
+
+    #[test]
+    fn test_predicate_conversion_boolean_column_false() {
+        let sql = "foo = false";
+        let predicate = convert_to_iceberg_predicate(sql).unwrap();
+        let expected_predicate = Reference::new("foo").equal_to(Datum::bool(false));
+        assert_eq!(predicate, expected_predicate);
+    }
+
+    #[test]
+    fn test_predicate_conversion_column_as_boolean() {
+        let predicate =
+            convert_filters_to_predicate(&vec![Expr::Column(Column::new_unqualified("foo"))])
+                .unwrap();
+        let expected_predicate = Reference::new("foo").equal_to(Datum::bool(true));
+        assert_eq!(predicate, expected_predicate);
+    }
+
+    #[test]
+    fn test_predicate_conversion_column_as_boolean_inside_not() {
+        let predicate = convert_filters_to_predicate(&vec![Expr::Not(Box::new(Expr::Column(
+            Column::new_unqualified("foo"),
+        )))])
+        .unwrap();
+        let expected_predicate = Reference::new("foo").equal_to(Datum::bool(false));
         assert_eq!(predicate, expected_predicate);
     }
 

--- a/website/src/release.md
+++ b/website/src/release.md
@@ -253,15 +253,7 @@ Checklist for reference:
 [ ] All source files have ASF headers
 [ ] Can compile from source
 
-More detailed checklist please refer to:
-https://github.com/apache/iceberg-rust/tree/main/scripts
-
-To compile from source, please refer to:
-https://github.com/apache/iceberg-rust/blob/main/CONTRIBUTING.md
-
-Here is a Python script in release to help you verify the release candidate:
-
-./scripts/verify.py
+More details please refer to https://rust.iceberg.apache.org/release.html#how-to-verify-a-release.
 
 Thanks
 

--- a/website/src/release.md
+++ b/website/src/release.md
@@ -306,6 +306,33 @@ ${name}
 
 Example: <https://lists.apache.org/thread/xk5myl10mztcfotn59oo59s4ckvojds6>
 
+## How to verify a release
+
+### Validating a source release
+
+A release contains links to following things:
+
+* A source tarball
+* A signature(.asc)
+* A checksum(.sha512)
+
+After downloading them, here are the instructions on how to verify them.
+
+* Import keys:
+
+```bash
+curl https://downloads.apache.org/iceberg/KEYS -o KEYS
+gpg --import KEYS
+```
+* Verify the `.asc` file: ```gpg --verify apache-iceberg-rust-${iceberg_version}.tar.gz.asc```
+* Verify the checksums: ```shasum -a 512 apache-iceberg-rust-${iceberg_version}.tar.gz.sha512```
+* Verify build and test:
+```bash
+tar -xzf apache-iceberg-rust-${iceberg_version}.tar.gz
+cd apache-iceberg-rust-${iceberg_version}
+make build && make test
+```
+
 ## Official Release
 
 ### Push the release git tag


### PR DESCRIPTION
This PR is just for helping reviewing our current changes against the main branch of iceberg-rust. **It should not be merged.**

Uses our opendal fork: https://github.com/advanced-development/opendal/pull/1

## AI Generated description:
This pull request includes several changes across multiple files to enhance functionality, improve accessibility, and add support for new features. The most significant updates involve enabling remote signing for S3 configurations, making previously restricted methods public, and adding detailed documentation to improve code clarity.

### Enhancements to S3 Configuration:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L90-R90): Updated the `opendal` dependency to point to a specific Git branch for remote signing support.
* [`crates/iceberg/src/io/storage_s3.rs`](diffhunk://#diff-c3be25e69451e9b6f8d3b3d8e9578af52973f400ac8901d97f679a17feec1113R68-R77): Added new constants and logic to support remote signing configurations, including options for enabling remote signing, specifying a signer, and configuring signer-related properties. [[1]](diffhunk://#diff-c3be25e69451e9b6f8d3b3d8e9578af52973f400ac8901d97f679a17feec1113R68-R77) [[2]](diffhunk://#diff-c3be25e69451e9b6f8d3b3d8e9578af52973f400ac8901d97f679a17feec1113R160-R177)

### Accessibility Improvements:

* [`crates/iceberg/src/catalog/mod.rs`](diffhunk://#diff-04f26c83b3c614be6f6d6cfb6c4cefef9e01ec2d31395ac487cdcdff2dbae729L289-R289): Made the `build_method` for the `TableCommit` struct public to allow external usage.
* [`crates/iceberg/src/spec/manifest/writer.rs`](diffhunk://#diff-8bad2631bd3b9e765212c1c6fc0fa0ef4210b69c827a67ebe623bde134ee599aL204-R204): Changed the visibility of the `add_entry` method in `ManifestWriter` from `pub(crate)` to `pub` for broader accessibility.

### Documentation and Code Clarity:

* [`crates/iceberg/src/arrow/mod.rs`](diffhunk://#diff-13df24c60548872ab75207a9b5ce1bac86e86f5c5366417560817227f29c5eabL32-R33): Updated the visibility and added comments to the `record_batch_transformer` module to clarify its purpose.
* [`crates/iceberg/src/arrow/record_batch_transformer.rs`](diffhunk://#diff-640415fbb0b37eac6f774eff524fb364c4e54c02da3a3c0e355af5caa941007cL111-R113): Enhanced documentation for the `RecordBatchTransformer` struct and its methods, including `build` and `process_record_batch`, to provide detailed explanations of their functionality. [[1]](diffhunk://#diff-640415fbb0b37eac6f774eff524fb364c4e54c02da3a3c0e355af5caa941007cL111-R113) [[2]](diffhunk://#diff-640415fbb0b37eac6f774eff524fb364c4e54c02da3a3c0e355af5caa941007cL123-R125) [[3]](diffhunk://#diff-640415fbb0b37eac6f774eff524fb364c4e54c02da3a3c0e355af5caa941007cL136-R150)